### PR TITLE
feat: implement Blog placeholder page

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Blog | wadakatu</title>
-  <meta name="description" content="Tech articles and learnings by wadakatu.">
+  <meta name="description" content="Tech articles and learnings by wadakatu. Currently publishing on Zenn.">
   <meta name="author" content="wadakatu">
 
   <!-- OGP -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://wadakatu.github.io/blog">
   <meta property="og:title" content="Blog | wadakatu">
-  <meta property="og:description" content="Tech articles and learnings by wadakatu.">
+  <meta property="og:description" content="Tech articles and learnings by wadakatu. Currently publishing on Zenn.">
   <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
   <meta property="og:site_name" content="wadakatu">
 
@@ -22,6 +22,266 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../styles/common.css">
+  <style>
+    /* ===== BLOG PAGE STYLES ===== */
+
+    .blog-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      gap: 2rem;
+      padding: 2rem 0;
+    }
+
+    /* Terminal Window */
+    .terminal-window {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      width: 100%;
+      max-width: 600px;
+      overflow: hidden;
+    }
+
+    .terminal-header {
+      background: rgba(0, 0, 0, 0.4);
+      padding: 0.75rem 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .terminal-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--border);
+    }
+
+    .terminal-dot.red { background: #ff5f56; }
+    .terminal-dot.yellow { background: #ffbd2e; }
+    .terminal-dot.green { background: #27c93f; }
+
+    .terminal-title {
+      flex: 1;
+      text-align: center;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      color: var(--text-dim);
+      margin-right: 54px;
+    }
+
+    .terminal-body {
+      padding: 1.5rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      text-align: left;
+    }
+
+    .terminal-line {
+      margin-bottom: 0.75rem;
+      line-height: 1.6;
+    }
+
+    .terminal-line:last-child {
+      margin-bottom: 0;
+    }
+
+    .prompt {
+      color: var(--matrix);
+    }
+
+    .cmd {
+      color: var(--text);
+    }
+
+    .output {
+      color: var(--text-dim);
+      padding-left: 1rem;
+    }
+
+    .output.highlight {
+      color: var(--matrix);
+    }
+
+    .output.warning {
+      color: #ffbd2e;
+    }
+
+    .cursor {
+      display: inline-block;
+      width: 8px;
+      height: 14px;
+      background: var(--matrix);
+      animation: blink 1s step-end infinite;
+      vertical-align: middle;
+      margin-left: 4px;
+    }
+
+    /* Status Badge */
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.75rem;
+      color: #ffbd2e;
+      background: rgba(255, 189, 46, 0.1);
+      border: 1px solid rgba(255, 189, 46, 0.3);
+      padding: 0.5rem 1rem;
+      border-radius: 20px;
+    }
+
+    .status-badge::before {
+      content: '';
+      width: 8px;
+      height: 8px;
+      background: #ffbd2e;
+      border-radius: 50%;
+      animation: pulse 2s infinite;
+    }
+
+    /* Info Section */
+    .info-section {
+      max-width: 500px;
+    }
+
+    .info-title {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+    }
+
+    .info-title .highlight {
+      color: var(--matrix);
+      text-shadow: var(--glow);
+    }
+
+    .info-text {
+      color: var(--text-dim);
+      line-height: 1.6;
+      margin-bottom: 1.5rem;
+    }
+
+    /* Zenn Link */
+    .zenn-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.9rem;
+      color: var(--bg);
+      background: var(--matrix);
+      padding: 0.875rem 1.5rem;
+      border-radius: 8px;
+      text-decoration: none;
+      transition: all 0.3s ease;
+      box-shadow: var(--glow);
+    }
+
+    .zenn-link:hover {
+      background: #00cc35;
+      box-shadow: var(--glow-strong);
+      transform: translateY(-2px);
+    }
+
+    .zenn-link svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    /* Roadmap Section */
+    .roadmap {
+      width: 100%;
+      max-width: 500px;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      text-align: left;
+    }
+
+    .roadmap-title {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      color: var(--matrix);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .roadmap-title::before {
+      content: '$';
+      opacity: 0.5;
+    }
+
+    .roadmap-list {
+      list-style: none;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+    }
+
+    .roadmap-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.5rem 0;
+      color: var(--text-dim);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .roadmap-item:last-child {
+      border-bottom: none;
+    }
+
+    .roadmap-status {
+      font-size: 0.9rem;
+    }
+
+    .roadmap-status.done {
+      color: var(--matrix);
+    }
+
+    .roadmap-status.pending {
+      color: var(--text-dim);
+    }
+
+    /* Animations */
+    .terminal-window,
+    .status-badge,
+    .info-section,
+    .zenn-link,
+    .roadmap {
+      opacity: 0;
+      transform: translateY(20px);
+      animation: fadeUp 0.6s ease-out forwards;
+    }
+
+    .status-badge { animation-delay: 0.1s; }
+    .terminal-window { animation-delay: 0.2s; }
+    .info-section { animation-delay: 0.4s; }
+    .zenn-link { animation-delay: 0.5s; }
+    .roadmap { animation-delay: 0.6s; }
+
+    /* Typing animation for terminal */
+    .typing {
+      overflow: hidden;
+      white-space: nowrap;
+      animation: typing 0.5s steps(20) forwards;
+    }
+
+    @keyframes typing {
+      from { width: 0; }
+      to { width: 100%; }
+    }
+  </style>
 </head>
 <body>
   <canvas id="matrix-rain"></canvas>
@@ -37,14 +297,69 @@
       <h1 class="page-title">Blog<span class="highlight">_</span></h1>
     </header>
 
-    <main class="coming-soon">
-      <span class="coming-soon-icon">📝</span>
-      <h2 class="coming-soon-title">COMING SOON</h2>
-      <p class="coming-soon-text">
-        Tech articles and learnings will be published here. In the meantime, check out my Zenn articles.
-      </p>
-      <div class="coming-soon-terminal">
-        <span class="prompt">$</span> loading articles<span class="cursor"></span>
+    <main class="blog-content">
+      <span class="status-badge">UNDER CONSTRUCTION</span>
+
+      <div class="terminal-window">
+        <div class="terminal-header">
+          <span class="terminal-dot red"></span>
+          <span class="terminal-dot yellow"></span>
+          <span class="terminal-dot green"></span>
+          <span class="terminal-title">blog@wadakatu: ~</span>
+        </div>
+        <div class="terminal-body">
+          <div class="terminal-line">
+            <span class="prompt">$</span> <span class="cmd">cat /dev/blog</span>
+          </div>
+          <div class="terminal-line">
+            <span class="output warning">Warning: /dev/blog is empty</span>
+          </div>
+          <div class="terminal-line">
+            <span class="output">No articles found in local repository.</span>
+          </div>
+          <div class="terminal-line">
+            <span class="output highlight">Redirecting to external source...</span>
+          </div>
+          <div class="terminal-line">
+            <span class="prompt">$</span> <span class="cmd">open https://zenn.dev/wadakatu</span><span class="cursor"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="info-section">
+        <h2 class="info-title">Coming Soon<span class="highlight">_</span></h2>
+        <p class="info-text">
+          Tech articles will be published here in the future. For now, check out my articles on Zenn.
+        </p>
+      </div>
+
+      <a href="https://zenn.dev/wadakatu" target="_blank" class="zenn-link">
+        <svg viewBox="0 0 24 24" fill="currentColor">
+          <path d="M.264 23.771h4.984c.264 0 .498-.147.645-.352L19.614.874c.176-.293-.029-.645-.381-.645h-4.72c-.235 0-.44.117-.557.323L.03 23.361c-.088.176.029.41.234.41zM17.445 23.419l6.479-10.408c.205-.323-.029-.733-.41-.733h-4.691c-.176 0-.352.088-.44.235l-6.655 10.643c-.176.264.029.616.352.616h4.779c.234-.001.468-.118.586-.353z"/>
+        </svg>
+        View Articles on Zenn
+      </a>
+
+      <div class="roadmap">
+        <h3 class="roadmap-title">roadmap.txt</h3>
+        <ul class="roadmap-list">
+          <li class="roadmap-item">
+            <span class="roadmap-status done">&#10003;</span>
+            <span>Setup blog page structure</span>
+          </li>
+          <li class="roadmap-item">
+            <span class="roadmap-status pending">&#9675;</span>
+            <span>Add markdown article support</span>
+          </li>
+          <li class="roadmap-item">
+            <span class="roadmap-status pending">&#9675;</span>
+            <span>Create article detail pages</span>
+          </li>
+          <li class="roadmap-item">
+            <span class="roadmap-status pending">&#9675;</span>
+            <span>Migrate articles from Zenn</span>
+          </li>
+        </ul>
       </div>
     </main>
 


### PR DESCRIPTION
## Summary
- Add terminal window showing `$ cat /dev/blog` command with redirect to Zenn
- Add UNDER CONSTRUCTION status badge (yellow/amber)
- Add Coming Soon section explaining future plans
- Add prominent "View Articles on Zenn" button with green glow
- Add roadmap section showing planned features:
  - ✓ Setup blog page structure
  - ○ Add markdown article support
  - ○ Create article detail pages
  - ○ Migrate articles from Zenn

## Test plan
- [ ] Verify page loads correctly at `/blog`
- [ ] Check Matrix theme consistency
- [ ] Test Zenn link opens correctly
- [ ] Verify responsive layout on mobile

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)