### PR TITLE
fix: update internal links to external URLs

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -467,7 +467,7 @@
             <span class="bio-line"><span class="output">Active <span class="highlight">OSS contributor</span> to Laravel ecosystem.</span></span>
             <span class="bio-line"><span class="output">Based in <span class="highlight">Osaka, Japan</span>.</span></span>
           </div>
-          <a href="/resume" class="resume-link">
+          <a href="https://wadakatu.github.io/resume" target="_blank" class="resume-link">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
               <polyline points="14 2 14 8 20 8"/>

--- a/index.html
+++ b/index.html
@@ -691,7 +691,7 @@
     <section class="featured">
       <h2 class="section-label">cat featured.txt</h2>
       <div class="featured-grid">
-        <a href="/w3c-hackathon" class="featured-card">
+        <a href="https://github.com/wadakatu/w3c-hackathon" target="_blank" class="featured-card">
           <span class="featured-badge">WINNER</span>
           <span class="featured-type">Project</span>
           <h3 class="featured-title">W3C Hackathon - TPAC 2025</h3>


### PR DESCRIPTION
## Summary

- 内部リンクを適切な外部URLに変更
- サブページを自前で作成せず、既存のリソースへリンク

## Changes

| ページ | 変更前 | 変更後 |
|-------|-------|-------|
| `index.html` | `/w3c-hackathon` | `https://github.com/wadakatu/w3c-hackathon` |
| `about/index.html` | `/resume` | `https://wadakatu.github.io/resume` |

## Test plan

- [x] chrome-devtools MCPでリンク先を確認済み
- [ ] ホームページからW3C Hackathonリンクをクリックしてリポジトリが開くことを確認
- [ ] AboutページからResumeリンクをクリックしてGitHub Pagesが開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)