### PR TITLE
feat: add automatic articles.json generation

### DIFF
--- a/.github/workflows/generate-articles.yml
+++ b/.github/workflows/generate-articles.yml
@@ -1,0 +1,41 @@
+name: Generate Articles JSON
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'articles/**'
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate articles.json
+        run: node scripts/generate-articles.js
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git diff --quiet data/articles.json || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/articles.json
+          git commit -m "chore: auto-generate articles.json"
+          git push

--- a/data/articles.json
+++ b/data/articles.json
@@ -4,7 +4,13 @@
     "title": "W3C TPAC 2025参加レポ （Web標準ってどうやってできてるの？）",
     "emoji": "🧑‍💻",
     "type": "idea",
-    "topics": ["w3c", "report", "tpac", "kobe", "worldwideweb"],
+    "topics": [
+      "w3c",
+      "report",
+      "tpac",
+      "kobe",
+      "worldwideweb"
+    ],
     "published_at": "2025-12-10T13:20:00"
   },
   {
@@ -12,15 +18,25 @@
     "title": "\\5を追加したら動いた！iTerm2でPhpStormを起動する設定方法",
     "emoji": "🥷",
     "type": "tech",
-    "topics": ["terminal", "phpstorm", "iterm2"],
+    "topics": [
+      "terminal",
+      "phpstorm",
+      "iterm2"
+    ],
     "published_at": "2025-08-12T09:47:00"
   },
   {
     "slug": "431afa748fbed1",
-    "title": "Claude Code × Serena MCP：もうバージョンダウンしなくても良いのか...?",
+    "title": "🚀 Claude Code × Serena MCP：もうバージョンダウンしなくても良いのか...?",
     "emoji": "👩‍💻",
     "type": "tech",
-    "topics": ["ai", "mcp", "claude", "vibecoding", "serena"],
+    "topics": [
+      "ai",
+      "mcp",
+      "claude",
+      "vibecoding",
+      "serena"
+    ],
     "published_at": "2025-07-31T11:13:00"
   },
   {
@@ -28,15 +44,27 @@
     "title": "Contextual Bindingの仕様変更について（Lumen v10 -> v11）",
     "emoji": "🫠",
     "type": "tech",
-    "topics": ["laravel", "php", "lumen", "servicecontainer", "contextualbinding"],
+    "topics": [
+      "laravel",
+      "php",
+      "lumen",
+      "servicecontainer",
+      "contextualbinding"
+    ],
     "published_at": "2025-04-14T11:26:00"
   },
   {
     "slug": "ce0260ada646f4",
-    "title": "php artisan schema:dumpで TLS/SSLに関するエラーが出た時の対処法",
+    "title": "`php artisan schema:dump`で `TLS/SSL`に関するエラーが出た時の対処法",
     "emoji": "🤪",
     "type": "tech",
-    "topics": ["laravel", "mysql", "php", "mariadb", "mysqldump"],
+    "topics": [
+      "laravel",
+      "mysql",
+      "php",
+      "mariadb",
+      "mysqldump"
+    ],
     "published_at": "2025-02-03T14:13:00"
   },
   {
@@ -44,7 +72,13 @@
     "title": "pecl install grpcで大量のwarningメッセージ出た時の対処法",
     "emoji": "🤫",
     "type": "tech",
-    "topics": ["php", "grpc", "dockerfile", "gnu", "pecl"],
+    "topics": [
+      "php",
+      "grpc",
+      "dockerfile",
+      "gnu",
+      "pecl"
+    ],
     "published_at": "2024-12-04T13:40:00"
   },
   {
@@ -52,7 +86,12 @@
     "title": "[Laravel] 最も簡単で最も難しい419エラーの解決策",
     "emoji": "🍪",
     "type": "tech",
-    "topics": ["laravel", "php", "csrf", "419"],
+    "topics": [
+      "laravel",
+      "php",
+      "csrf",
+      "419"
+    ],
     "published_at": "2024-04-22T20:49:00"
   },
   {
@@ -60,7 +99,13 @@
     "title": "[Laravel Subscriber] 関数名を文字列で定義するの怖くない？",
     "emoji": "🫥",
     "type": "tech",
-    "topics": ["laravel", "php", "phpunit", "mockery", "suscriber"],
+    "topics": [
+      "laravel",
+      "php",
+      "phpunit",
+      "mockery",
+      "suscriber"
+    ],
     "published_at": "2024-04-05T12:07:00"
   },
   {
@@ -68,7 +113,11 @@
     "title": "[Framer motion] アニメーション動作後にposition: fixedが効かない時の対処法",
     "emoji": "🤕",
     "type": "tech",
-    "topics": ["framer", "react", "framermotion"],
+    "topics": [
+      "framer",
+      "react",
+      "framermotion"
+    ],
     "published_at": "2024-01-14T02:18:00"
   },
   {
@@ -76,7 +125,13 @@
     "title": "Next.js初心者がLogを出すまでに苦労した話",
     "emoji": "🙇‍♂️",
     "type": "tech",
-    "topics": ["next", "typescript", "ecs", "logger", "pino"],
+    "topics": [
+      "next",
+      "typescript",
+      "ecs",
+      "logger",
+      "pino"
+    ],
     "published_at": "2023-08-18T15:52:00"
   },
   {
@@ -84,7 +139,13 @@
     "title": "sendgrid-nodejsでbaseUrlを変更するときに注意すること",
     "emoji": "👹",
     "type": "tech",
-    "topics": ["javascript", "typescript", "node", "sendgrid", "sendgridnodejs"],
+    "topics": [
+      "javascript",
+      "typescript",
+      "node",
+      "sendgrid",
+      "sendgridnodejs"
+    ],
     "published_at": "2023-07-31T23:55:00"
   },
   {
@@ -92,7 +153,11 @@
     "title": "【Next.js v13】 Metadata APIを使ってFaviconを設定",
     "emoji": "🧿",
     "type": "tech",
-    "topics": ["javascript", "nextjs", "favicon"],
+    "topics": [
+      "javascript",
+      "nextjs",
+      "favicon"
+    ],
     "published_at": "2023-07-25T17:32:00"
   },
   {
@@ -100,7 +165,11 @@
     "title": "Laravel & Inertiaのテストでresource/js以外をテスト対象にする方法",
     "emoji": "⛳",
     "type": "tech",
-    "topics": ["laravel", "inertia", "pest"],
+    "topics": [
+      "laravel",
+      "inertia",
+      "pest"
+    ],
     "published_at": "2023-03-27T20:03:00"
   },
   {
@@ -108,7 +177,13 @@
     "title": "PHP/Composerなしで始めるLaravel/Sail入門",
     "emoji": "⚡",
     "type": "tech",
-    "topics": ["docker", "laravel", "php", "composer", "sail"],
+    "topics": [
+      "docker",
+      "laravel",
+      "php",
+      "composer",
+      "sail"
+    ],
     "published_at": "2023-01-17T18:03:00"
   },
   {
@@ -116,7 +191,10 @@
     "title": "【vimeo.js】doNotTrack is not defined.",
     "emoji": "🔖",
     "type": "tech",
-    "topics": ["javascript", "vimeo"],
+    "topics": [
+      "javascript",
+      "vimeo"
+    ],
     "published_at": "2023-01-16T10:38:00"
   },
   {
@@ -124,7 +202,12 @@
     "title": "【Inertia.js】[object Object] could not be cloned.の対処法",
     "emoji": "😎",
     "type": "tech",
-    "topics": ["javascript", "laravel", "inertia", "channeltalk"],
+    "topics": [
+      "javascript",
+      "laravel",
+      "inertia",
+      "channeltalk"
+    ],
     "published_at": "2023-01-06T14:40:00"
   }
 ]

--- a/scripts/generate-articles.js
+++ b/scripts/generate-articles.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+/**
+ * Generate articles.json from markdown frontmatter
+ *
+ * Usage: node scripts/generate-articles.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ARTICLES_DIR = path.join(__dirname, '..', 'articles');
+const OUTPUT_FILE = path.join(__dirname, '..', 'data', 'articles.json');
+
+/**
+ * Parse YAML frontmatter from markdown content
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const yaml = match[1];
+  const data = {};
+
+  // Parse simple YAML (key: value and arrays)
+  let currentKey = null;
+  let inArray = false;
+  const arrayValues = [];
+
+  for (const line of yaml.split('\n')) {
+    // Array item
+    if (line.match(/^\s+-\s+/)) {
+      const value = line.replace(/^\s+-\s+/, '').replace(/^["']|["']$/g, '');
+      arrayValues.push(value);
+      continue;
+    }
+
+    // Save previous array if exists
+    if (inArray && currentKey) {
+      data[currentKey] = [...arrayValues];
+      arrayValues.length = 0;
+      inArray = false;
+    }
+
+    // Key: value pair
+    const kvMatch = line.match(/^(\w+):\s*(.*)$/);
+    if (kvMatch) {
+      const [, key, value] = kvMatch;
+      currentKey = key;
+
+      if (value === '') {
+        // Start of array
+        inArray = true;
+      } else {
+        // Parse value
+        let parsed = value.replace(/^["']|["']$/g, '');
+
+        // Handle escaped characters in title
+        if (key === 'title') {
+          parsed = parsed.replace(/\\(.)/g, '$1');
+        }
+
+        // Boolean
+        if (parsed === 'true') parsed = true;
+        else if (parsed === 'false') parsed = false;
+
+        data[key] = parsed;
+      }
+    }
+  }
+
+  // Save last array if exists
+  if (inArray && currentKey) {
+    data[currentKey] = [...arrayValues];
+  }
+
+  return data;
+}
+
+/**
+ * Parse published_at string to ISO format
+ */
+function parsePublishedAt(dateStr) {
+  if (!dateStr) return null;
+
+  // Handle "2025-08-12 09:47" format
+  const match = dateStr.match(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})$/);
+  if (match) {
+    return `${match[1]}T${match[2]}:00`;
+  }
+
+  return dateStr;
+}
+
+/**
+ * Main function
+ */
+function main() {
+  // Read all markdown files
+  const files = fs.readdirSync(ARTICLES_DIR)
+    .filter(f => f.endsWith('.md'));
+
+  const articles = [];
+
+  for (const file of files) {
+    const filePath = path.join(ARTICLES_DIR, file);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const frontmatter = parseFrontmatter(content);
+
+    if (!frontmatter) {
+      console.warn(`Warning: No frontmatter found in ${file}`);
+      continue;
+    }
+
+    // Skip unpublished articles
+    if (frontmatter.published !== true) {
+      console.log(`Skipping unpublished: ${file}`);
+      continue;
+    }
+
+    const slug = file.replace('.md', '');
+
+    articles.push({
+      slug,
+      title: frontmatter.title || '',
+      emoji: frontmatter.emoji || '',
+      type: frontmatter.type || 'tech',
+      topics: frontmatter.topics || [],
+      published_at: parsePublishedAt(frontmatter.published_at) || ''
+    });
+  }
+
+  // Sort by published_at (newest first)
+  articles.sort((a, b) => {
+    if (!a.published_at) return 1;
+    if (!b.published_at) return -1;
+    return b.published_at.localeCompare(a.published_at);
+  });
+
+  // Ensure data directory exists
+  const dataDir = path.dirname(OUTPUT_FILE);
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+
+  // Write JSON
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(articles, null, 2) + '\n');
+
+  console.log(`Generated ${OUTPUT_FILE} with ${articles.length} articles`);
+}
+
+main();


### PR DESCRIPTION
## Summary

`articles/` ディレクトリのMarkdownファイルから `data/articles.json` を自動生成する機能を追加。

## New Files

| ファイル | 内容 |
|---------|------|
| `scripts/generate-articles.js` | frontmatterを解析してJSONを生成 |
| `.github/workflows/generate-articles.yml` | 自動実行ワークフロー |

## How It Works

1. `articles/` に変更がpushされると GitHub Actions が起動
2. `node scripts/generate-articles.js` を実行
3. `data/articles.json` に差分があれば自動コミット

## Features

- `published: false` の記事は除外
- `published_at` で降順ソート（新しい順）
- frontmatterの YAML を自前で解析（外部依存なし）

## Manual Usage

```bash
node scripts/generate-articles.js
```

## 新規記事追加ワークフロー（更新後）

1. `articles/new-slug.md` を作成（Zenn フォーマット）
2. `git push` → 自動で `articles.json` が更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)