### PR TITLE
New Feature: Add code copy button for code blocks

### DIFF
--- a/blog/article.html
+++ b/blog/article.html
@@ -361,6 +361,119 @@
       border-bottom: 1px solid var(--border);
     }
 
+    /* ===== CODE COPY BUTTON ===== */
+    .code-copy-btn {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      color: var(--text-dim);
+      background: rgba(0, 0, 0, 0.4);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+      opacity: 0;
+      transform: translateY(-4px);
+      transition: all 0.25s ease;
+      z-index: 10;
+      backdrop-filter: blur(4px);
+      -webkit-backdrop-filter: blur(4px);
+    }
+
+    .markdown-body pre:hover .code-copy-btn,
+    .code-copy-btn:focus {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .code-copy-btn:hover {
+      color: var(--matrix);
+      border-color: var(--matrix-dark);
+      background: rgba(0, 255, 65, 0.08);
+      box-shadow:
+        0 0 20px rgba(0, 255, 65, 0.15),
+        inset 0 0 20px rgba(0, 255, 65, 0.05);
+    }
+
+    .code-copy-btn .copy-icon,
+    .code-copy-btn .check-icon {
+      width: 14px;
+      height: 14px;
+      transition: all 0.2s ease;
+    }
+
+    .code-copy-btn .check-icon {
+      display: none;
+    }
+
+    .code-copy-btn.copied {
+      color: var(--matrix);
+      border-color: var(--matrix-dim);
+      background: rgba(0, 255, 65, 0.12);
+      box-shadow:
+        0 0 25px rgba(0, 255, 65, 0.25),
+        inset 0 0 15px rgba(0, 255, 65, 0.1);
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .code-copy-btn.copied .copy-icon {
+      display: none;
+    }
+
+    .code-copy-btn.copied .check-icon {
+      display: block;
+      animation: checkPop 0.3s ease;
+    }
+
+    .code-copy-btn .btn-label {
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    @keyframes checkPop {
+      0% { transform: scale(0.5); opacity: 0; }
+      50% { transform: scale(1.2); }
+      100% { transform: scale(1); opacity: 1; }
+    }
+
+    @keyframes glowPulse {
+      0%, 100% {
+        box-shadow:
+          0 0 20px rgba(0, 255, 65, 0.2),
+          inset 0 0 15px rgba(0, 255, 65, 0.1);
+      }
+      50% {
+        box-shadow:
+          0 0 30px rgba(0, 255, 65, 0.35),
+          inset 0 0 20px rgba(0, 255, 65, 0.15);
+      }
+    }
+
+    .code-copy-btn.copied {
+      animation: glowPulse 0.6s ease;
+    }
+
+    .code-copy-btn:focus-visible {
+      outline: 2px solid var(--matrix);
+      outline-offset: 2px;
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    @media (max-width: 768px) {
+      .code-copy-btn {
+        opacity: 1;
+        transform: translateY(0);
+        padding: 8px 12px;
+      }
+    }
+
     /* Blockquote */
     .markdown-body blockquote {
       margin: 1.5rem 0;
@@ -780,6 +893,79 @@
       document.querySelectorAll('pre code').forEach((block) => {
         hljs.highlightElement(block);
       });
+
+      // Initialize code copy buttons
+      initCodeCopyButtons();
+    }
+
+    /**
+     * Initialize code copy buttons for all code blocks
+     */
+    function initCodeCopyButtons() {
+      const codeBlocks = document.querySelectorAll('.markdown-body pre');
+
+      codeBlocks.forEach((pre) => {
+        if (pre.querySelector('.code-copy-btn')) return;
+
+        const button = document.createElement('button');
+        button.className = 'code-copy-btn';
+        button.setAttribute('aria-label', 'Copy code to clipboard');
+        button.setAttribute('title', 'Copy code');
+        button.innerHTML = `
+          <svg class="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+          </svg>
+          <svg class="check-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="20 6 9 17 4 12"/>
+          </svg>
+          <span class="btn-label">Copy</span>
+        `;
+
+        button.addEventListener('click', async () => {
+          const code = pre.querySelector('code');
+          if (!code) return;
+
+          try {
+            await navigator.clipboard.writeText(code.textContent);
+            showCopySuccess(button);
+          } catch (err) {
+            // Fallback for older browsers
+            const textArea = document.createElement('textarea');
+            textArea.value = code.textContent;
+            textArea.style.position = 'fixed';
+            textArea.style.opacity = '0';
+            document.body.appendChild(textArea);
+            textArea.select();
+
+            try {
+              document.execCommand('copy');
+              showCopySuccess(button);
+            } catch (e) {
+              button.querySelector('.btn-label').textContent = 'Failed';
+              setTimeout(() => {
+                button.querySelector('.btn-label').textContent = 'Copy';
+              }, 2000);
+            }
+
+            document.body.removeChild(textArea);
+          }
+        });
+
+        pre.appendChild(button);
+      });
+    }
+
+    function showCopySuccess(button) {
+      button.classList.add('copied');
+      button.querySelector('.btn-label').textContent = 'Copied!';
+      button.setAttribute('aria-label', 'Code copied to clipboard');
+
+      setTimeout(() => {
+        button.classList.remove('copied');
+        button.querySelector('.btn-label').textContent = 'Copy';
+        button.setAttribute('aria-label', 'Copy code to clipboard');
+      }, 2000);
     }
 
     function showError(message) {


### PR DESCRIPTION
# 概要

ブログ記事内のコードブロックにコピーボタンを追加し、開発者向けUXを向上させる機能です。

## 変更内容

- コードブロックの右上にコピーボタンUIを追加（Matrix緑テーマに合わせたデザイン）
- クリップボードAPIでコピー機能を実装（古いブラウザ向けfallback付き）
- コピー成功時に「Copied!」フィードバックとチェックマークアニメーションを表示
- Highlight.jsとの統合
- アクセシビリティ対応（aria-label, focus-visible）
- モバイル対応（常時表示）

## 関連情報

- Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)