### PR TITLE
feat: モバイルブラウザUI統合のためtheme-colorメタタグを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,9 @@
   <meta name="twitter:description" content="Backend Developer @ Studio Inc. Building no-code website builders. Active OSS contributor to Laravel ecosystem.">
   <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
 
+  <!-- Theme Color -->
+  <meta name="theme-color" content="#0a0a0a">
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="./ogp.webp">
 


### PR DESCRIPTION
# 概要

モバイルブラウザのUIカラーをサイトのダークテーマに合わせるため、`meta theme-color` タグを追加しました。

## 変更内容

- `index.html` に `<meta name="theme-color" content="#0a0a0a">` を追加
- サイトの背景色（`#0a0a0a`）と同じ色を指定し、ブラウザのアドレスバー・ステータスバーとの一体感を向上

### 効果
- **Android Chrome**: アドレスバーがサイトの黒色に統一される
- **iOS Safari 15+**: ステータスバーの色が変更される
- **PWA**: アプリとして起動時のテーマカラーに反映

## 関連情報

- Closes #29