### PR TITLE
feat: add meta tags, skip links, and noscript fallbacks (Issue #40)

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,6 +7,24 @@
   <meta name="description" content="You've reached a dead end in the Matrix. Make your choice.">
   <meta name="robots" content="noindex">
 
+  <!-- OGP -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://wadakatu.github.io/404.html">
+  <meta property="og:title" content="404 - Page Not Found | wadakatu">
+  <meta property="og:description" content="The path you seek does not exist in this reality.">
+  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
+  <meta property="og:site_name" content="wadakatu">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@koyolympus">
+  <meta name="twitter:creator" content="@koyolympus">
+  <meta name="twitter:title" content="404 - Page Not Found | wadakatu">
+  <meta name="twitter:description" content="The path you seek does not exist in this reality.">
+  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
+
   <link rel="icon" type="image/webp" href="./ogp.webp">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -553,12 +571,37 @@
       white-space: nowrap;
       border: 0;
     }
+
+    /* Skip Link - Hidden until focused */
+    .skip-link {
+      position: absolute;
+      top: -100%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--matrix);
+      color: var(--bg);
+      padding: 0.75rem 1.5rem;
+      border-radius: 0 0 8px 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      z-index: 10001;
+      transition: top 0.3s ease;
+    }
+
+    .skip-link:focus {
+      top: 0;
+      outline: 2px solid var(--text);
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <canvas id="matrix-rain" aria-hidden="true"></canvas>
 
-  <main class="container" role="main">
+  <main id="main-content" class="container" role="main">
     <!-- Glitchy 404 -->
     <div class="glitch-wrapper">
       <h1 class="glitch" aria-label="404 Error">404</h1>
@@ -666,5 +709,18 @@
       drops = Array(columns).fill(0).map(() => Math.random() * -100);
     });
   </script>
+
+  <noscript>
+    <style>
+      #matrix-rain { display: none; }
+      body::before, body::after { display: none; }
+      .glitch-wrapper, .subtitle, .terminal, .choice-section, .terminal-line {
+        opacity: 1;
+        transform: none;
+      }
+      .glitch::before, .glitch::after { display: none; }
+      .cursor { animation: none; opacity: 1; }
+    </style>
+  </noscript>
 </body>
 </html>

--- a/about/index.html
+++ b/about/index.html
@@ -13,7 +13,17 @@
   <meta property="og:title" content="About | wadakatu">
   <meta property="og:description" content="Career and skills of wadakatu - Backend Developer @ Studio Inc. Active OSS contributor to Laravel ecosystem.">
   <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@koyolympus">
+  <meta name="twitter:creator" content="@koyolympus">
+  <meta name="twitter:title" content="About | wadakatu">
+  <meta name="twitter:description" content="Career and skills of wadakatu - Backend Developer @ Studio Inc. Active OSS contributor to Laravel ecosystem.">
+  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
 
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">
@@ -437,9 +447,34 @@
     .stats-section { animation-delay: 0.25s; }
     .stack-section { animation-delay: 0.35s; }
     .oss-section { animation-delay: 0.45s; }
+
+    /* Skip Link - Hidden until focused */
+    .skip-link {
+      position: absolute;
+      top: -100%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--matrix);
+      color: var(--bg);
+      padding: 0.75rem 1.5rem;
+      border-radius: 0 0 8px 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      z-index: 10000;
+      transition: top 0.3s ease;
+    }
+
+    .skip-link:focus {
+      top: 0;
+      outline: 2px solid var(--text);
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <canvas id="matrix-rain" aria-hidden="true"></canvas>
 
   <div class="container">
@@ -453,7 +488,7 @@
       <h1 class="page-title">About<span class="highlight">_</span></h1>
     </header>
 
-    <main class="about-content">
+    <main id="main-content" class="about-content">
       <!-- Profile Section -->
       <section class="profile-section">
         <div class="profile-header">
@@ -629,5 +664,16 @@
         });
     }
   </script>
+
+  <noscript>
+    <style>
+      #matrix-rain { display: none; }
+      body::before { display: none; }
+      .page-header, .profile-section, .stats-section, .stack-section, .oss-section, .footer {
+        opacity: 1;
+        transform: none;
+      }
+    </style>
+  </noscript>
 </body>
 </html>

--- a/blog/article.html
+++ b/blog/article.html
@@ -13,6 +13,7 @@
   <meta property="og:title" id="og-title" content="Article | wadakatu">
   <meta property="og:description" id="og-description" content="Tech article by wadakatu">
   <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
   <meta property="og:locale" content="ja_JP">
 
@@ -22,6 +23,7 @@
   <meta name="twitter:title" id="twitter-title" content="Article | wadakatu">
   <meta name="twitter:description" id="twitter-description" content="Tech article by wadakatu">
   <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
 
   <!-- Canonical URL -->
   <link rel="canonical" id="canonical-url" href="https://wadakatu.github.io/blog/article.html">
@@ -692,9 +694,34 @@
     .zenn-bar { animation-delay: 0.2s; }
     .article-content { animation-delay: 0.3s; }
     .article-footer { animation-delay: 0.4s; }
+
+    /* Skip Link - Hidden until focused */
+    .skip-link {
+      position: absolute;
+      top: -100%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--matrix);
+      color: var(--bg);
+      padding: 0.75rem 1.5rem;
+      border-radius: 0 0 8px 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      z-index: 10000;
+      transition: top 0.3s ease;
+    }
+
+    .skip-link:focus {
+      top: 0;
+      outline: 2px solid var(--text);
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <canvas id="matrix-rain" aria-hidden="true"></canvas>
 
   <div class="container">
@@ -707,7 +734,7 @@
       </a>
     </header>
 
-    <main class="article-container" id="article-main">
+    <main class="article-container" id="main-content">
       <!-- Loading State -->
       <div class="loading-state" id="loading-state">
         <div class="loading-spinner"></div>
@@ -1027,5 +1054,24 @@
         });
     }
   </script>
+
+  <noscript>
+    <style>
+      #matrix-rain { display: none; }
+      body::before { display: none; }
+      .page-header, .article-header, .zenn-bar, .article-content, .article-footer, .footer {
+        opacity: 1;
+        transform: none;
+      }
+      #loading-state { display: none; }
+    </style>
+    <div style="text-align: center; padding: 3rem; font-family: 'JetBrains Mono', monospace; color: #888;">
+      <p>JavaScript is required to load this article.</p>
+      <p style="margin-top: 1rem;">
+        <a href="/blog" style="color: #00ff41;">Return to Blog</a> or
+        <a href="https://zenn.dev/wadakatu" style="color: #00ff41;">Visit Zenn</a>
+      </p>
+    </div>
+  </noscript>
 </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,7 +13,18 @@
   <meta property="og:title" content="Blog | wadakatu">
   <meta property="og:description" content="Tech articles and learnings by wadakatu - Laravel, TypeScript, and web development.">
   <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
+  <meta property="og:locale" content="ja_JP">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@koyolympus">
+  <meta name="twitter:creator" content="@koyolympus">
+  <meta name="twitter:title" content="Blog | wadakatu">
+  <meta name="twitter:description" content="Tech articles and learnings by wadakatu - Laravel, TypeScript, and web development.">
+  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
 
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">
@@ -335,9 +346,34 @@
     .blog-stats { animation-delay: 0.2s; }
     .category-section { animation-delay: 0.3s; }
     .articles-list { animation-delay: 0.4s; }
+
+    /* Skip Link - Hidden until focused */
+    .skip-link {
+      position: absolute;
+      top: -100%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--matrix);
+      color: var(--bg);
+      padding: 0.75rem 1.5rem;
+      border-radius: 0 0 8px 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      z-index: 10000;
+      transition: top 0.3s ease;
+    }
+
+    .skip-link:focus {
+      top: 0;
+      outline: 2px solid var(--text);
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <canvas id="matrix-rain" aria-hidden="true"></canvas>
 
   <div class="container">
@@ -351,7 +387,7 @@
       <h1 class="page-title">Blog<span class="highlight">_</span></h1>
     </header>
 
-    <main class="blog-content">
+    <main id="main-content" class="blog-content">
       <!-- Stats Header -->
       <div class="blog-stats">
         <div class="stats-info">
@@ -418,5 +454,25 @@
         });
     }
   </script>
+
+  <noscript>
+    <style>
+      #matrix-rain { display: none; }
+      body::before { display: none; }
+      .page-header, .blog-stats, .category-section, .articles-list, .footer {
+        opacity: 1;
+        transform: none;
+      }
+      .loading { display: none; }
+      #articles-container::before {
+        content: 'JavaScript is required to load articles. Please enable JavaScript or visit Zenn directly.';
+        display: block;
+        padding: 2rem;
+        text-align: center;
+        color: var(--text-dim);
+        font-family: 'JetBrains Mono', monospace;
+      }
+    </style>
+  </noscript>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <meta property="og:title" content="wadakatu | Backend Developer">
   <meta property="og:description" content="Backend Developer @ Studio Inc. Building no-code website builders. Active OSS contributor to Laravel ecosystem.">
   <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
   <meta property="og:locale" content="ja_JP">
 
@@ -23,6 +24,7 @@
   <meta name="twitter:title" content="wadakatu | Backend Developer">
   <meta name="twitter:description" content="Backend Developer @ Studio Inc. Building no-code website builders. Active OSS contributor to Laravel ecosystem.">
   <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
 
   <!-- Theme Color -->
   <meta name="theme-color" content="#0a0a0a">

--- a/offline.html
+++ b/offline.html
@@ -6,6 +6,24 @@
   <title>Offline | wadakatu</title>
   <meta name="description" content="You are currently offline.">
 
+  <!-- OGP -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://wadakatu.github.io/offline.html">
+  <meta property="og:title" content="Offline | wadakatu">
+  <meta property="og:description" content="You are currently offline. Cached pages are available.">
+  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
+  <meta property="og:site_name" content="wadakatu">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@koyolympus">
+  <meta name="twitter:creator" content="@koyolympus">
+  <meta name="twitter:title" content="Offline | wadakatu">
+  <meta name="twitter:description" content="You are currently offline. Cached pages are available.">
+  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
+
   <link rel="icon" type="image/webp" href="/ogp.webp">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -418,9 +436,34 @@
         display: none;
       }
     }
+
+    /* Skip Link - Hidden until focused */
+    .skip-link {
+      position: absolute;
+      top: -100%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--matrix);
+      color: var(--bg);
+      padding: 0.75rem 1.5rem;
+      border-radius: 0 0 8px 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      z-index: 10001;
+      transition: top 0.3s ease;
+    }
+
+    .skip-link:focus {
+      top: 0;
+      outline: 2px solid var(--text);
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <!-- CRT Effect Overlay -->
   <div class="crt-container" aria-hidden="true"></div>
 
@@ -428,7 +471,7 @@
   <div class="matrix-rain" aria-hidden="true" id="matrix-rain"></div>
 
   <!-- Main Content -->
-  <main class="offline-content">
+  <main id="main-content" class="offline-content">
     <!-- Glitch Title -->
     <div class="glitch-wrapper">
       <h1 class="glitch" data-text="OFFLINE">OFFLINE</h1>
@@ -515,5 +558,14 @@
       location.reload();
     });
   </script>
+
+  <noscript>
+    <style>
+      .matrix-rain { display: none; }
+      .crt-container::before, .crt-container::after { display: none; }
+      .glitch::before, .glitch::after, .glitch { animation: none; }
+      .terminal-cursor { animation: none; opacity: 1; }
+    </style>
+  </noscript>
 </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -13,7 +13,17 @@
   <meta property="og:title" content="Projects | wadakatu">
   <meta property="og:description" content="OSS contributions and personal projects by wadakatu - Laravel, TypeScript, and frontend experiments.">
   <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@koyolympus">
+  <meta name="twitter:creator" content="@koyolympus">
+  <meta name="twitter:title" content="Projects | wadakatu">
+  <meta name="twitter:description" content="OSS contributions and personal projects by wadakatu - Laravel, TypeScript, and frontend experiments.">
+  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
 
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">
@@ -391,9 +401,34 @@
       animation: fadeUp 0.5s ease-out forwards;
       animation-delay: 1s;
     }
+
+    /* Skip Link - Hidden until focused */
+    .skip-link {
+      position: absolute;
+      top: -100%;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--matrix);
+      color: var(--bg);
+      padding: 0.75rem 1.5rem;
+      border-radius: 0 0 8px 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      z-index: 10000;
+      transition: top 0.3s ease;
+    }
+
+    .skip-link:focus {
+      top: 0;
+      outline: 2px solid var(--text);
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <canvas id="matrix-rain" aria-hidden="true"></canvas>
 
   <div class="container">
@@ -407,7 +442,7 @@
       <h1 class="page-title">Projects<span class="highlight">_</span></h1>
     </header>
 
-    <main class="projects-content">
+    <main id="main-content" class="projects-content">
       <!-- Stats Bar -->
       <div class="stats-bar">
         <div class="stat-item">
@@ -597,5 +632,16 @@
         });
     }
   </script>
+
+  <noscript>
+    <style>
+      #matrix-rain { display: none; }
+      body::before { display: none; }
+      .page-header, .stats-bar, .featured-card, .other-card, .terminal-output, .footer {
+        opacity: 1;
+        transform: none;
+      }
+    </style>
+  </noscript>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Issue #40の対応として、以下の整備を実施しました：

- ✅ OGP/Twitter Cardメタタグの追加・整備
- ✅ 言語属性の整備（blog/index.htmlを`lang="ja"`に変更）
- ✅ スキップリンクの追加（キーボードナビゲーション対応）
- ✅ noscriptフォールバックの追加（JavaScript無効時の対応）

## 変更内容

### 全ページ共通
- `og:image:alt`と`twitter:image:alt`を追加（画像の代替テキスト）

### about/projects/blog/404/offline ページ
- Twitter Cardメタタグ一式を追加
- スキップリンク（`.skip-link`）をbody直後に追加
- `<main>`タグに`id="main-content"`を追加
- noscriptフォールバックを追加（アニメーション無効化、代替表示）

### 404/offlineページ
- OGPメタタグ一式を新規追加

### blog/index.html
- `lang="en"` → `lang="ja"`に変更（日本語コンテンツ主体のため）
- `og:locale="ja_JP"`を追加

### blog/article.html
- noscriptに「記事を読み込めません」メッセージ + Zenn/ブログ一覧へのリンクを追加

## テスト項目
- [x] ローカルサーバーで全ページの表示確認
- [x] chrome-devtoolsでメタタグの存在確認
- [x] スキップリンクの動作確認
- [x] blog/index.htmlのlang属性が"ja"になっていることを確認

## 備考
- スキップリンクはTabキーでフォーカス時に画面上部に表示されます
- noscriptフォールバックにより、JavaScript無効時もコンテンツが読めるようになりました

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)