### PR TITLE
feat: unify canonical domain to www.wadakatu.dev

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,10 +9,10 @@
 
   <!-- OGP -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://wadakatu.github.io/404.html">
+  <meta property="og:url" content="https://www.wadakatu.dev/404.html">
   <meta property="og:title" content="404 - Page Not Found | wadakatu">
   <meta property="og:description" content="The path you seek does not exist in this reality.">
-  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
 
@@ -22,7 +22,7 @@
   <meta name="twitter:creator" content="@koyolympus">
   <meta name="twitter:title" content="404 - Page Not Found | wadakatu">
   <meta name="twitter:description" content="The path you seek does not exist in this reality.">
-  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
 
   <link rel="icon" type="image/webp" href="./ogp.webp">

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Personal portfolio website for wadakatu (Backend Developer). Static site hosted on GitHub Pages at https://wadakatu.github.io/.
+Personal portfolio website for wadakatu (Backend Developer). Static site hosted on GitHub Pages at https://www.wadakatu.dev/.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **`> Backend Developer @ Osaka, Japan`**
 
-[![Live Site](https://img.shields.io/badge/LIVE-wadakatu.github.io-000000?style=for-the-badge&logo=github&logoColor=00ff41&labelColor=000000&color=004d00)](https://wadakatu.github.io)
+[![Live Site](https://img.shields.io/badge/LIVE-www.wadakatu.dev-000000?style=for-the-badge&logo=github&logoColor=00ff41&labelColor=000000&color=004d00)](https://www.wadakatu.dev)
 
 </div>
 
@@ -18,7 +18,7 @@ $ cat site_info.txt
 
 | Key | Value |
 |-----|-------|
-| `URL` | https://wadakatu.github.io |
+| `URL` | https://www.wadakatu.dev |
 | `STATUS` | ![](https://img.shields.io/badge/●_ONLINE-004d00?style=flat-square&labelColor=004d00) |
 | `STACK` | HTML / CSS / JavaScript |
 | `HOST` | GitHub Pages |

--- a/about/index.html
+++ b/about/index.html
@@ -9,10 +9,10 @@
 
   <!-- OGP -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://wadakatu.github.io/about">
+  <meta property="og:url" content="https://www.wadakatu.dev/about">
   <meta property="og:title" content="About | wadakatu">
   <meta property="og:description" content="Career and skills of wadakatu - Backend Developer @ Studio Inc. Active OSS contributor to Laravel ecosystem.">
-  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
 
@@ -22,8 +22,11 @@
   <meta name="twitter:creator" content="@koyolympus">
   <meta name="twitter:title" content="About | wadakatu">
   <meta name="twitter:description" content="Career and skills of wadakatu - Backend Developer @ Studio Inc. Active OSS contributor to Laravel ecosystem.">
-  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.wadakatu.dev/about">
 
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">
@@ -505,7 +508,7 @@
             <span class="bio-line"><span class="output">Active <span class="highlight">OSS contributor</span> to Laravel ecosystem.</span></span>
             <span class="bio-line"><span class="output">Based in <span class="highlight">Osaka, Japan</span>.</span></span>
           </div>
-          <a href="https://wadakatu.github.io/resume" target="_blank" class="resume-link">
+          <a href="https://www.wadakatu.dev/resume" target="_blank" class="resume-link">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
               <polyline points="14 2 14 8 20 8"/>

--- a/blog/article.html
+++ b/blog/article.html
@@ -9,10 +9,10 @@
 
   <!-- OGP (dynamically updated by JavaScript) -->
   <meta property="og:type" content="article">
-  <meta property="og:url" id="og-url" content="https://wadakatu.github.io/blog/article.html">
+  <meta property="og:url" id="og-url" content="https://www.wadakatu.dev/blog/article.html">
   <meta property="og:title" id="og-title" content="Article | wadakatu">
   <meta property="og:description" id="og-description" content="Tech article by wadakatu">
-  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
   <meta property="og:locale" content="ja_JP">
@@ -22,11 +22,11 @@
   <meta name="twitter:site" content="@koyolympus">
   <meta name="twitter:title" id="twitter-title" content="Article | wadakatu">
   <meta name="twitter:description" id="twitter-description" content="Tech article by wadakatu">
-  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
 
   <!-- Canonical URL -->
-  <link rel="canonical" id="canonical-url" href="https://wadakatu.github.io/blog/article.html">
+  <link rel="canonical" id="canonical-url" href="https://www.wadakatu.dev/blog/article.html">
 
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">
@@ -811,7 +811,7 @@
     }
 
     function updateMetaTags(metadata) {
-      const articleUrl = `https://wadakatu.github.io/blog/article.html?slug=${metadata.slug}`;
+      const articleUrl = `https://www.wadakatu.dev/blog/article.html?slug=${metadata.slug}`;
       const description = `${metadata.title} - Tech article by wadakatu`;
 
       // Update page meta tags

--- a/blog/index.html
+++ b/blog/index.html
@@ -9,10 +9,10 @@
 
   <!-- OGP -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://wadakatu.github.io/blog">
+  <meta property="og:url" content="https://www.wadakatu.dev/blog">
   <meta property="og:title" content="Blog | wadakatu">
   <meta property="og:description" content="Tech articles and learnings by wadakatu - Laravel, TypeScript, and web development.">
-  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
   <meta property="og:locale" content="ja_JP">
@@ -23,8 +23,11 @@
   <meta name="twitter:creator" content="@koyolympus">
   <meta name="twitter:title" content="Blog | wadakatu">
   <meta name="twitter:description" content="Tech articles and learnings by wadakatu - Laravel, TypeScript, and web development.">
-  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.wadakatu.dev/blog">
 
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">

--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
 
   <!-- OGP -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://wadakatu.github.io/">
+  <meta property="og:url" content="https://www.wadakatu.dev/">
   <meta property="og:title" content="wadakatu | Backend Developer">
   <meta property="og:description" content="Backend Developer @ Studio Inc. Building no-code website builders. Active OSS contributor to Laravel ecosystem.">
-  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
   <meta property="og:locale" content="ja_JP">
@@ -23,8 +23,11 @@
   <meta name="twitter:creator" content="@koyolympus">
   <meta name="twitter:title" content="wadakatu | Backend Developer">
   <meta name="twitter:description" content="Backend Developer @ Studio Inc. Building no-code website builders. Active OSS contributor to Laravel ecosystem.">
-  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.wadakatu.dev/">
 
   <!-- Theme Color -->
   <meta name="theme-color" content="#0a0a0a">
@@ -39,7 +42,7 @@
     "@type": "ProfilePage",
     "mainEntity": {
       "@type": "Person",
-      "@id": "https://wadakatu.github.io/#person",
+      "@id": "https://www.wadakatu.dev/#person",
       "name": "wadakatu",
       "alternateName": "koyolympus",
       "jobTitle": "Backend Developer",
@@ -48,8 +51,8 @@
         "name": "Studio Inc."
       },
       "description": "Backend Developer @ Studio Inc. Building no-code website builders. Active OSS contributor to Laravel ecosystem. Creator of laravel-spectrum & gitlyte.",
-      "url": "https://wadakatu.github.io/",
-      "image": "https://wadakatu.github.io/ogp.webp",
+      "url": "https://www.wadakatu.dev/",
+      "image": "https://www.wadakatu.dev/ogp.webp",
       "address": {
         "@type": "PostalAddress",
         "addressLocality": "Osaka",
@@ -86,7 +89,7 @@
           "description": "Dashboard built with vibe-coding, guided by web-standards. Winner project.",
           "url": "https://github.com/wadakatu/w3c-hackathon",
           "author": {
-            "@id": "https://wadakatu.github.io/#person"
+            "@id": "https://www.wadakatu.dev/#person"
           }
         }
       },
@@ -99,7 +102,7 @@
           "description": "Zero-annotation API documentation generator for Laravel.",
           "url": "https://docs.laravel-spectrum.dev",
           "author": {
-            "@id": "https://wadakatu.github.io/#person"
+            "@id": "https://www.wadakatu.dev/#person"
           },
           "programmingLanguage": "PHP"
         }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -123,11 +123,11 @@ This portfolio website is intentionally built with minimal dependencies:
 
 | Page | URL | Description |
 |------|-----|-------------|
-| Home | https://wadakatu.github.io/ | Main portfolio with navigation hub |
-| Projects | https://wadakatu.github.io/projects | OSS contributions and personal works |
-| Blog | https://wadakatu.github.io/blog | Technical articles and learnings |
-| About | https://wadakatu.github.io/about | Career history and detailed skills |
-| 404 | https://wadakatu.github.io/404.html | Custom error page with Matrix theme |
+| Home | https://www.wadakatu.dev/ | Main portfolio with navigation hub |
+| Projects | https://www.wadakatu.dev/projects | OSS contributions and personal works |
+| Blog | https://www.wadakatu.dev/blog | Technical articles and learnings |
+| About | https://www.wadakatu.dev/about | Career history and detailed skills |
+| 404 | https://www.wadakatu.dev/404.html | Custom error page with Matrix theme |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -29,10 +29,10 @@ Location: Osaka, Japan
 
 ## Site Structure
 
-- [Homepage](https://wadakatu.github.io/): Main portfolio page with navigation hub
-- [Projects](https://wadakatu.github.io/projects): OSS contributions and personal works
-- [Blog](https://wadakatu.github.io/blog): Technical articles and learnings
-- [About](https://wadakatu.github.io/about): Career history and skills
+- [Homepage](https://www.wadakatu.dev/): Main portfolio page with navigation hub
+- [Projects](https://www.wadakatu.dev/projects): OSS contributions and personal works
+- [Blog](https://www.wadakatu.dev/blog): Technical articles and learnings
+- [About](https://www.wadakatu.dev/about): Career history and skills
 
 ## Technical Stack
 

--- a/offline.html
+++ b/offline.html
@@ -8,10 +8,10 @@
 
   <!-- OGP -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://wadakatu.github.io/offline.html">
+  <meta property="og:url" content="https://www.wadakatu.dev/offline.html">
   <meta property="og:title" content="Offline | wadakatu">
   <meta property="og:description" content="You are currently offline. Cached pages are available.">
-  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
 
@@ -21,7 +21,7 @@
   <meta name="twitter:creator" content="@koyolympus">
   <meta name="twitter:title" content="Offline | wadakatu">
   <meta name="twitter:description" content="You are currently offline. Cached pages are available.">
-  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
 
   <link rel="icon" type="image/webp" href="/ogp.webp">
@@ -487,7 +487,7 @@
       </div>
       <div class="terminal-line">
         <span class="terminal-prompt">$</span>
-        <span class="terminal-text">ping wadakatu.github.io</span>
+        <span class="terminal-text">ping www.wadakatu.dev</span>
       </div>
       <div class="terminal-line">
         <span class="terminal-prompt">&gt;</span>

--- a/projects/index.html
+++ b/projects/index.html
@@ -9,10 +9,10 @@
 
   <!-- OGP -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://wadakatu.github.io/projects">
+  <meta property="og:url" content="https://www.wadakatu.dev/projects">
   <meta property="og:title" content="Projects | wadakatu">
   <meta property="og:description" content="OSS contributions and personal projects by wadakatu - Laravel, TypeScript, and frontend experiments.">
-  <meta property="og:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta property="og:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta property="og:image:alt" content="wadakatu - Backend Developer portfolio preview">
   <meta property="og:site_name" content="wadakatu">
 
@@ -22,8 +22,11 @@
   <meta name="twitter:creator" content="@koyolympus">
   <meta name="twitter:title" content="Projects | wadakatu">
   <meta name="twitter:description" content="OSS contributions and personal projects by wadakatu - Laravel, TypeScript, and frontend experiments.">
-  <meta name="twitter:image" content="https://wadakatu.github.io/ogp.webp">
+  <meta name="twitter:image" content="https://www.wadakatu.dev/ogp.webp">
   <meta name="twitter:image:alt" content="wadakatu - Backend Developer portfolio preview">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.wadakatu.dev/projects">
 
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">

--- a/robots.txt
+++ b/robots.txt
@@ -1,11 +1,11 @@
-# robots.txt for wadakatu.github.io
+# robots.txt for www.wadakatu.dev
 
 User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://wadakatu.github.io/sitemap.xml
+Sitemap: https://www.wadakatu.dev/sitemap.xml
 
 # AI crawlers - welcome to use llms.txt
-# See: https://wadakatu.github.io/llms.txt
-# Full content: https://wadakatu.github.io/llms-full.txt
+# See: https://www.wadakatu.dev/llms.txt
+# Full content: https://www.wadakatu.dev/llms-full.txt

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const BASE_URL = 'https://wadakatu.github.io';
+const BASE_URL = 'https://www.wadakatu.dev';
 const ARTICLES_JSON = path.join(__dirname, '..', 'data', 'articles.json');
 const OUTPUT_FILE = path.join(__dirname, '..', 'sitemap.xml');
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://wadakatu.github.io/</loc>
+    <loc>https://www.wadakatu.dev/</loc>
     <lastmod>2025-01-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://wadakatu.github.io/projects</loc>
+    <loc>https://www.wadakatu.dev/projects</loc>
     <lastmod>2025-01-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://wadakatu.github.io/blog</loc>
+    <loc>https://www.wadakatu.dev/blog</loc>
     <lastmod>2025-01-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://wadakatu.github.io/about</loc>
+    <loc>https://www.wadakatu.dev/about</loc>
     <lastmod>2025-01-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://wadakatu.github.io/llms.txt</loc>
+    <loc>https://www.wadakatu.dev/llms.txt</loc>
     <lastmod>2025-01-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://wadakatu.github.io/llms-full.txt</loc>
+    <loc>https://www.wadakatu.dev/llms-full.txt</loc>
     <lastmod>2025-01-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Summary

- Replace all `wadakatu.github.io` URLs with `www.wadakatu.dev` (52 locations across 14 files)
- Add canonical tags to 5 main pages (index, blog, about, projects, blog/index)
- Update SEO and crawler files (sitemap.xml, robots.txt, llms.txt, llms-full.txt)
- Update generate-sitemap.js BASE_URL constant
- Update offline.html terminal display text to reflect new domain

## Details

This PR consolidates all URLs to the custom domain (`www.wadakatu.dev`) as specified in the CNAME file, resolving SEO evaluation fragmentation.

### Files Changed (14)

**Phase 1: SEO/Crawler Files**
- sitemap.xml (6 URLs)
- robots.txt (4 locations)
- llms.txt (4 URLs)
- llms-full.txt (5 URLs)

**Phase 2: Scripts**
- scripts/generate-sitemap.js (BASE_URL constant)

**Phase 3: HTML Pages**
- index.html (8 URLs + canonical added)
- blog/index.html (3 URLs + canonical added)
- blog/article.html (5 URLs - canonical already existed)
- about/index.html (4 URLs + canonical added)
- projects/index.html (3 URLs + canonical added)
- 404.html (3 URLs - no canonical due to noindex)
- offline.html (4 locations - no canonical as it's a SW page)

**Phase 4: Documentation**
- README.md (2 URLs)
- CLAUDE.md (1 URL)

## Acceptance Criteria

- [x] All public URLs unified to https://www.wadakatu.dev
- [x] Canonical tags added to all main pages
- [x] sitemap/robots/llms files updated to use custom domain
- [ ] Verify OGP displays correctly on all pages
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Verify canonical tags are correctly set
- [ ] Validate sitemap.xml

## Closes

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)