### PR TITLE
feat: RSS/Atomフィード生成とブログ記事静的ページ生成機能

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>wadakatu Blog</title>
+  <subtitle>Tech articles and learnings by wadakatu - Laravel, TypeScript, and web development.</subtitle>
+  <link href="https://www.wadakatu.dev/blog/" rel="alternate" type="text/html"/>
+  <link href="https://www.wadakatu.dev/atom.xml" rel="self" type="application/atom+xml"/>
+  <id>https://www.wadakatu.dev/blog/</id>
+  <updated>2025-12-10T04:20:00.000Z</updated>
+  <author>
+    <name>wadakatu</name>
+    <uri>https://www.wadakatu.dev</uri>
+  </author>
+  <rights>Copyright 2026 wadakatu</rights>
+  <icon>https://www.wadakatu.dev/ogp.webp</icon>
+  <logo>https://www.wadakatu.dev/ogp.webp</logo>
+  <entry>
+    <title>🧑‍💻 W3C TPAC 2025参加レポ （Web標準ってどうやってできてるの？）</title>
+    <link href="https://www.wadakatu.dev/blog/da5be52d57e9a1/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/da5be52d57e9a1/</id>
+    <published>2025-12-10T04:20:00.000Z</published>
+    <updated>2025-12-10T04:20:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Life"/>
+    <category term="w3c"/>
+    <category term="report"/>
+    <category term="tpac"/>
+    <category term="kobe"/>
+    <category term="worldwideweb"/>
+  </entry>
+  <entry>
+    <title>🥷 \5を追加したら動いた！iTerm2でPhpStormを起動する設定方法</title>
+    <link href="https://www.wadakatu.dev/blog/c438613853e766/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/c438613853e766/</id>
+    <published>2025-08-12T00:47:00.000Z</published>
+    <updated>2025-08-12T00:47:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="terminal"/>
+    <category term="phpstorm"/>
+    <category term="iterm2"/>
+  </entry>
+  <entry>
+    <title>👩‍💻 🚀 Claude Code × Serena MCP：もうバージョンダウンしなくても良いのか...?</title>
+    <link href="https://www.wadakatu.dev/blog/431afa748fbed1/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/431afa748fbed1/</id>
+    <published>2025-07-31T02:13:00.000Z</published>
+    <updated>2025-07-31T02:13:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="ai"/>
+    <category term="mcp"/>
+    <category term="claude"/>
+    <category term="vibecoding"/>
+    <category term="serena"/>
+  </entry>
+  <entry>
+    <title>🫠 Contextual Bindingの仕様変更について（Lumen v10 -&gt; v11）</title>
+    <link href="https://www.wadakatu.dev/blog/2b6012f10b777d/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/2b6012f10b777d/</id>
+    <published>2025-04-14T02:26:00.000Z</published>
+    <updated>2025-04-14T02:26:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="laravel"/>
+    <category term="php"/>
+    <category term="lumen"/>
+    <category term="servicecontainer"/>
+    <category term="contextualbinding"/>
+  </entry>
+  <entry>
+    <title>🤪 `php artisan schema:dump`で `TLS/SSL`に関するエラーが出た時の対処法</title>
+    <link href="https://www.wadakatu.dev/blog/ce0260ada646f4/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/ce0260ada646f4/</id>
+    <published>2025-02-03T05:13:00.000Z</published>
+    <updated>2025-02-03T05:13:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="laravel"/>
+    <category term="mysql"/>
+    <category term="php"/>
+    <category term="mariadb"/>
+    <category term="mysqldump"/>
+  </entry>
+  <entry>
+    <title>🤫 pecl install grpcで大量のwarningメッセージ出た時の対処法</title>
+    <link href="https://www.wadakatu.dev/blog/ad3ddb6ff13abe/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/ad3ddb6ff13abe/</id>
+    <published>2024-12-04T04:40:00.000Z</published>
+    <updated>2024-12-04T04:40:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="php"/>
+    <category term="grpc"/>
+    <category term="dockerfile"/>
+    <category term="gnu"/>
+    <category term="pecl"/>
+  </entry>
+  <entry>
+    <title>🍪 [Laravel] 最も簡単で最も難しい419エラーの解決策</title>
+    <link href="https://www.wadakatu.dev/blog/f3948e577a3b65/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/f3948e577a3b65/</id>
+    <published>2024-04-22T11:49:00.000Z</published>
+    <updated>2024-04-22T11:49:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="laravel"/>
+    <category term="php"/>
+    <category term="csrf"/>
+    <category term="419"/>
+  </entry>
+  <entry>
+    <title>🫥 [Laravel Subscriber] 関数名を文字列で定義するの怖くない？</title>
+    <link href="https://www.wadakatu.dev/blog/01a6f8c9376ff1/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/01a6f8c9376ff1/</id>
+    <published>2024-04-05T03:07:00.000Z</published>
+    <updated>2024-04-05T03:07:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="laravel"/>
+    <category term="php"/>
+    <category term="phpunit"/>
+    <category term="mockery"/>
+    <category term="suscriber"/>
+  </entry>
+  <entry>
+    <title>🤕 [Framer motion] アニメーション動作後にposition: fixedが効かない時の対処法</title>
+    <link href="https://www.wadakatu.dev/blog/46d7b3e367d930/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/46d7b3e367d930/</id>
+    <published>2024-01-13T17:18:00.000Z</published>
+    <updated>2024-01-13T17:18:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="framer"/>
+    <category term="react"/>
+    <category term="framermotion"/>
+  </entry>
+  <entry>
+    <title>🙇‍♂️ Next.js初心者がLogを出すまでに苦労した話</title>
+    <link href="https://www.wadakatu.dev/blog/e78c7f39dab62f/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/e78c7f39dab62f/</id>
+    <published>2023-08-18T06:52:00.000Z</published>
+    <updated>2023-08-18T06:52:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="next"/>
+    <category term="typescript"/>
+    <category term="ecs"/>
+    <category term="logger"/>
+    <category term="pino"/>
+  </entry>
+  <entry>
+    <title>👹 sendgrid-nodejsでbaseUrlを変更するときに注意すること</title>
+    <link href="https://www.wadakatu.dev/blog/d261ae9bcb4d6b/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/d261ae9bcb4d6b/</id>
+    <published>2023-07-31T14:55:00.000Z</published>
+    <updated>2023-07-31T14:55:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="javascript"/>
+    <category term="typescript"/>
+    <category term="node"/>
+    <category term="sendgrid"/>
+    <category term="sendgridnodejs"/>
+  </entry>
+  <entry>
+    <title>🧿 【Next.js v13】 Metadata APIを使ってFaviconを設定</title>
+    <link href="https://www.wadakatu.dev/blog/33b761aeb80772/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/33b761aeb80772/</id>
+    <published>2023-07-25T08:32:00.000Z</published>
+    <updated>2023-07-25T08:32:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="javascript"/>
+    <category term="nextjs"/>
+    <category term="favicon"/>
+  </entry>
+  <entry>
+    <title>⛳ Laravel &amp; Inertiaのテストでresource/js以外をテスト対象にする方法</title>
+    <link href="https://www.wadakatu.dev/blog/0b4b923b3c1edc/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/0b4b923b3c1edc/</id>
+    <published>2023-03-27T11:03:00.000Z</published>
+    <updated>2023-03-27T11:03:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="laravel"/>
+    <category term="inertia"/>
+    <category term="pest"/>
+  </entry>
+  <entry>
+    <title>⚡ PHP/Composerなしで始めるLaravel/Sail入門</title>
+    <link href="https://www.wadakatu.dev/blog/afc2c86306ca88/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/afc2c86306ca88/</id>
+    <published>2023-01-17T09:03:00.000Z</published>
+    <updated>2023-01-17T09:03:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="docker"/>
+    <category term="laravel"/>
+    <category term="php"/>
+    <category term="composer"/>
+    <category term="sail"/>
+  </entry>
+  <entry>
+    <title>🔖 【vimeo.js】doNotTrack is not defined.</title>
+    <link href="https://www.wadakatu.dev/blog/8b5deda18d7967/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/8b5deda18d7967/</id>
+    <published>2023-01-16T01:38:00.000Z</published>
+    <updated>2023-01-16T01:38:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="javascript"/>
+    <category term="vimeo"/>
+  </entry>
+  <entry>
+    <title>😎 【Inertia.js】[object Object] could not be cloned.の対処法</title>
+    <link href="https://www.wadakatu.dev/blog/3828103014143e/" rel="alternate" type="text/html"/>
+    <id>https://www.wadakatu.dev/blog/3828103014143e/</id>
+    <published>2023-01-06T05:40:00.000Z</published>
+    <updated>2023-01-06T05:40:00.000Z</updated>
+    <author>
+      <name>wadakatu</name>
+      <uri>https://www.wadakatu.dev</uri>
+    </author>
+    <category term="Tech"/>
+    <category term="javascript"/>
+    <category term="laravel"/>
+    <category term="inertia"/>
+    <category term="channeltalk"/>
+  </entry>
+</feed>

--- a/blog/index.html
+++ b/blog/index.html
@@ -35,6 +35,10 @@
   <!-- PWA Manifest -->
   <link rel="manifest" href="/manifest.json">
 
+  <!-- RSS Feed -->
+  <link rel="alternate" type="application/rss+xml" title="wadakatu Blog RSS Feed" href="https://www.wadakatu.dev/feed.xml">
+  <link rel="alternate" type="application/atom+xml" title="wadakatu Blog Atom Feed" href="https://www.wadakatu.dev/atom.xml">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
@@ -402,6 +406,12 @@
             <path d="M.264 23.771h4.984c.264 0 .498-.147.645-.352L19.614.874c.176-.293-.029-.645-.381-.645h-4.72c-.235 0-.44.117-.557.323L.03 23.361c-.088.176.029.41.234.41zM17.445 23.419l6.479-10.408c.205-.323-.029-.733-.41-.733h-4.691c-.176 0-.352.088-.44.235l-6.655 10.643c-.176.264.029.616.352.616h4.779c.234-.001.468-.118.586-.353z"/>
           </svg>
           Zenn Profile
+        </a>
+        <a href="/feed.xml" class="zenn-badge" title="Subscribe via RSS">
+          <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
+            <path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20C5 20 4 19 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/>
+          </svg>
+          RSS
         </a>
       </div>
 

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>wadakatu Blog</title>
+    <link>https://www.wadakatu.dev/blog/</link>
+    <description>Tech articles and learnings by wadakatu - Laravel, TypeScript, and web development.</description>
+    <language>ja</language>
+    <copyright>Copyright 2026 wadakatu</copyright>
+    <lastBuildDate>Wed, 07 Jan 2026 06:13:07 GMT</lastBuildDate>
+    <ttl>60</ttl>
+    <image>
+      <url>https://www.wadakatu.dev/ogp.webp</url>
+      <title>wadakatu Blog</title>
+      <link>https://www.wadakatu.dev/blog/</link>
+    </image>
+    <atom:link href="https://www.wadakatu.dev/feed.xml" rel="self" type="application/rss+xml"/>
+    <item>
+      <title>🧑‍💻 W3C TPAC 2025参加レポ （Web標準ってどうやってできてるの？）</title>
+      <link>https://www.wadakatu.dev/blog/da5be52d57e9a1/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/da5be52d57e9a1/</guid>
+      <pubDate>Wed, 10 Dec 2025 04:20:00 GMT</pubDate>
+      <category>Life</category>
+      <category>w3c</category>
+      <category>report</category>
+      <category>tpac</category>
+      <category>kobe</category>
+      <category>worldwideweb</category>
+    </item>
+    <item>
+      <title>🥷 \5を追加したら動いた！iTerm2でPhpStormを起動する設定方法</title>
+      <link>https://www.wadakatu.dev/blog/c438613853e766/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/c438613853e766/</guid>
+      <pubDate>Tue, 12 Aug 2025 00:47:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>terminal</category>
+      <category>phpstorm</category>
+      <category>iterm2</category>
+    </item>
+    <item>
+      <title>👩‍💻 🚀 Claude Code × Serena MCP：もうバージョンダウンしなくても良いのか...?</title>
+      <link>https://www.wadakatu.dev/blog/431afa748fbed1/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/431afa748fbed1/</guid>
+      <pubDate>Thu, 31 Jul 2025 02:13:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>ai</category>
+      <category>mcp</category>
+      <category>claude</category>
+      <category>vibecoding</category>
+      <category>serena</category>
+    </item>
+    <item>
+      <title>🫠 Contextual Bindingの仕様変更について（Lumen v10 -&gt; v11）</title>
+      <link>https://www.wadakatu.dev/blog/2b6012f10b777d/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/2b6012f10b777d/</guid>
+      <pubDate>Mon, 14 Apr 2025 02:26:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>laravel</category>
+      <category>php</category>
+      <category>lumen</category>
+      <category>servicecontainer</category>
+      <category>contextualbinding</category>
+    </item>
+    <item>
+      <title>🤪 `php artisan schema:dump`で `TLS/SSL`に関するエラーが出た時の対処法</title>
+      <link>https://www.wadakatu.dev/blog/ce0260ada646f4/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/ce0260ada646f4/</guid>
+      <pubDate>Mon, 03 Feb 2025 05:13:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>laravel</category>
+      <category>mysql</category>
+      <category>php</category>
+      <category>mariadb</category>
+      <category>mysqldump</category>
+    </item>
+    <item>
+      <title>🤫 pecl install grpcで大量のwarningメッセージ出た時の対処法</title>
+      <link>https://www.wadakatu.dev/blog/ad3ddb6ff13abe/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/ad3ddb6ff13abe/</guid>
+      <pubDate>Wed, 04 Dec 2024 04:40:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>php</category>
+      <category>grpc</category>
+      <category>dockerfile</category>
+      <category>gnu</category>
+      <category>pecl</category>
+    </item>
+    <item>
+      <title>🍪 [Laravel] 最も簡単で最も難しい419エラーの解決策</title>
+      <link>https://www.wadakatu.dev/blog/f3948e577a3b65/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/f3948e577a3b65/</guid>
+      <pubDate>Mon, 22 Apr 2024 11:49:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>laravel</category>
+      <category>php</category>
+      <category>csrf</category>
+      <category>419</category>
+    </item>
+    <item>
+      <title>🫥 [Laravel Subscriber] 関数名を文字列で定義するの怖くない？</title>
+      <link>https://www.wadakatu.dev/blog/01a6f8c9376ff1/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/01a6f8c9376ff1/</guid>
+      <pubDate>Fri, 05 Apr 2024 03:07:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>laravel</category>
+      <category>php</category>
+      <category>phpunit</category>
+      <category>mockery</category>
+      <category>suscriber</category>
+    </item>
+    <item>
+      <title>🤕 [Framer motion] アニメーション動作後にposition: fixedが効かない時の対処法</title>
+      <link>https://www.wadakatu.dev/blog/46d7b3e367d930/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/46d7b3e367d930/</guid>
+      <pubDate>Sat, 13 Jan 2024 17:18:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>framer</category>
+      <category>react</category>
+      <category>framermotion</category>
+    </item>
+    <item>
+      <title>🙇‍♂️ Next.js初心者がLogを出すまでに苦労した話</title>
+      <link>https://www.wadakatu.dev/blog/e78c7f39dab62f/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/e78c7f39dab62f/</guid>
+      <pubDate>Fri, 18 Aug 2023 06:52:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>next</category>
+      <category>typescript</category>
+      <category>ecs</category>
+      <category>logger</category>
+      <category>pino</category>
+    </item>
+    <item>
+      <title>👹 sendgrid-nodejsでbaseUrlを変更するときに注意すること</title>
+      <link>https://www.wadakatu.dev/blog/d261ae9bcb4d6b/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/d261ae9bcb4d6b/</guid>
+      <pubDate>Mon, 31 Jul 2023 14:55:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>javascript</category>
+      <category>typescript</category>
+      <category>node</category>
+      <category>sendgrid</category>
+      <category>sendgridnodejs</category>
+    </item>
+    <item>
+      <title>🧿 【Next.js v13】 Metadata APIを使ってFaviconを設定</title>
+      <link>https://www.wadakatu.dev/blog/33b761aeb80772/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/33b761aeb80772/</guid>
+      <pubDate>Tue, 25 Jul 2023 08:32:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>javascript</category>
+      <category>nextjs</category>
+      <category>favicon</category>
+    </item>
+    <item>
+      <title>⛳ Laravel &amp; Inertiaのテストでresource/js以外をテスト対象にする方法</title>
+      <link>https://www.wadakatu.dev/blog/0b4b923b3c1edc/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/0b4b923b3c1edc/</guid>
+      <pubDate>Mon, 27 Mar 2023 11:03:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>laravel</category>
+      <category>inertia</category>
+      <category>pest</category>
+    </item>
+    <item>
+      <title>⚡ PHP/Composerなしで始めるLaravel/Sail入門</title>
+      <link>https://www.wadakatu.dev/blog/afc2c86306ca88/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/afc2c86306ca88/</guid>
+      <pubDate>Tue, 17 Jan 2023 09:03:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>docker</category>
+      <category>laravel</category>
+      <category>php</category>
+      <category>composer</category>
+      <category>sail</category>
+    </item>
+    <item>
+      <title>🔖 【vimeo.js】doNotTrack is not defined.</title>
+      <link>https://www.wadakatu.dev/blog/8b5deda18d7967/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/8b5deda18d7967/</guid>
+      <pubDate>Mon, 16 Jan 2023 01:38:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>javascript</category>
+      <category>vimeo</category>
+    </item>
+    <item>
+      <title>😎 【Inertia.js】[object Object] could not be cloned.の対処法</title>
+      <link>https://www.wadakatu.dev/blog/3828103014143e/</link>
+      <guid isPermaLink="true">https://www.wadakatu.dev/blog/3828103014143e/</guid>
+      <pubDate>Fri, 06 Jan 2023 05:40:00 GMT</pubDate>
+      <category>Tech</category>
+      <category>javascript</category>
+      <category>laravel</category>
+      <category>inertia</category>
+      <category>channeltalk</category>
+    </item>
+  </channel>
+</rss>

--- a/scripts/generate-feed.js
+++ b/scripts/generate-feed.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+/**
+ * Generate RSS and Atom feeds from articles
+ *
+ * Usage: node scripts/generate-feed.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BASE_URL = 'https://www.wadakatu.dev';
+const ARTICLES_JSON = path.join(__dirname, '..', 'data', 'articles.json');
+const RSS_OUTPUT = path.join(__dirname, '..', 'feed.xml');
+const ATOM_OUTPUT = path.join(__dirname, '..', 'atom.xml');
+
+// Feed metadata
+const FEED_CONFIG = {
+  title: 'wadakatu Blog',
+  description: 'Tech articles and learnings by wadakatu - Laravel, TypeScript, and web development.',
+  author: {
+    name: 'wadakatu',
+    uri: 'https://www.wadakatu.dev'
+  },
+  language: 'ja',
+  copyright: `Copyright ${new Date().getFullYear()} wadakatu`,
+  feedUrl: {
+    rss: `${BASE_URL}/feed.xml`,
+    atom: `${BASE_URL}/atom.xml`
+  },
+  siteUrl: `${BASE_URL}/blog/`,
+  image: `${BASE_URL}/ogp.webp`,
+  ttl: 60, // Minutes between feed checks (RSS)
+  maxItems: 20 // Limit feed to most recent N articles
+};
+
+/**
+ * Escape XML special characters
+ */
+function escapeXml(text) {
+  if (!text) return '';
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Format date as RFC-822 (for RSS)
+ * Example: "Tue, 10 Dec 2025 13:20:00 +0900"
+ */
+function formatRfc822(dateString) {
+  const date = new Date(dateString);
+  return date.toUTCString();
+}
+
+/**
+ * Format date as ISO-8601 (for Atom)
+ * Example: "2025-12-10T13:20:00+09:00"
+ */
+function formatIso8601(dateString) {
+  const date = new Date(dateString);
+  return date.toISOString();
+}
+
+/**
+ * Get category from article type
+ */
+function getCategory(type) {
+  const categoryMap = { tech: 'Tech', idea: 'Life' };
+  return categoryMap[type] || 'Other';
+}
+
+/**
+ * Generate RSS 2.0 feed
+ */
+function generateRssFeed(articles) {
+  const items = articles.slice(0, FEED_CONFIG.maxItems).map(article => {
+    const articleUrl = `${BASE_URL}/blog/${article.slug}/`;
+    const category = getCategory(article.type);
+    const title = `${article.emoji} ${article.title}`;
+
+    // Generate category tags for type and topics
+    const categoryTags = [
+      `      <category>${escapeXml(category)}</category>`,
+      ...article.topics.map(topic => `      <category>${escapeXml(topic)}</category>`)
+    ].join('\n');
+
+    return `    <item>
+      <title>${escapeXml(title)}</title>
+      <link>${articleUrl}</link>
+      <guid isPermaLink="true">${articleUrl}</guid>
+      <pubDate>${formatRfc822(article.published_at)}</pubDate>
+${categoryTags}
+    </item>`;
+  });
+
+  const lastBuildDate = formatRfc822(new Date().toISOString());
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(FEED_CONFIG.title)}</title>
+    <link>${FEED_CONFIG.siteUrl}</link>
+    <description>${escapeXml(FEED_CONFIG.description)}</description>
+    <language>${FEED_CONFIG.language}</language>
+    <copyright>${escapeXml(FEED_CONFIG.copyright)}</copyright>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <ttl>${FEED_CONFIG.ttl}</ttl>
+    <image>
+      <url>${FEED_CONFIG.image}</url>
+      <title>${escapeXml(FEED_CONFIG.title)}</title>
+      <link>${FEED_CONFIG.siteUrl}</link>
+    </image>
+    <atom:link href="${FEED_CONFIG.feedUrl.rss}" rel="self" type="application/rss+xml"/>
+${items.join('\n')}
+  </channel>
+</rss>
+`;
+}
+
+/**
+ * Generate Atom 1.0 feed
+ */
+function generateAtomFeed(articles) {
+  const entries = articles.slice(0, FEED_CONFIG.maxItems).map(article => {
+    const articleUrl = `${BASE_URL}/blog/${article.slug}/`;
+    const category = getCategory(article.type);
+    const title = `${article.emoji} ${article.title}`;
+
+    // Generate category tags for type and topics
+    const categoryTags = [
+      `    <category term="${escapeXml(category)}"/>`,
+      ...article.topics.map(topic => `    <category term="${escapeXml(topic)}"/>`)
+    ].join('\n');
+
+    return `  <entry>
+    <title>${escapeXml(title)}</title>
+    <link href="${articleUrl}" rel="alternate" type="text/html"/>
+    <id>${articleUrl}</id>
+    <published>${formatIso8601(article.published_at)}</published>
+    <updated>${formatIso8601(article.published_at)}</updated>
+    <author>
+      <name>${escapeXml(FEED_CONFIG.author.name)}</name>
+      <uri>${FEED_CONFIG.author.uri}</uri>
+    </author>
+${categoryTags}
+  </entry>`;
+  });
+
+  // Use latest article's date as feed updated time, or current time if no articles
+  const updated = articles.length > 0
+    ? formatIso8601(articles[0].published_at)
+    : formatIso8601(new Date().toISOString());
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>${escapeXml(FEED_CONFIG.title)}</title>
+  <subtitle>${escapeXml(FEED_CONFIG.description)}</subtitle>
+  <link href="${FEED_CONFIG.siteUrl}" rel="alternate" type="text/html"/>
+  <link href="${FEED_CONFIG.feedUrl.atom}" rel="self" type="application/atom+xml"/>
+  <id>${FEED_CONFIG.siteUrl}</id>
+  <updated>${updated}</updated>
+  <author>
+    <name>${escapeXml(FEED_CONFIG.author.name)}</name>
+    <uri>${FEED_CONFIG.author.uri}</uri>
+  </author>
+  <rights>${escapeXml(FEED_CONFIG.copyright)}</rights>
+  <icon>${FEED_CONFIG.image}</icon>
+  <logo>${FEED_CONFIG.image}</logo>
+${entries.join('\n')}
+</feed>
+`;
+}
+
+/**
+ * Main function
+ */
+function main() {
+  console.log('Generating RSS and Atom feeds...\n');
+
+  // Load articles
+  if (!fs.existsSync(ARTICLES_JSON)) {
+    console.error('Error: articles.json not found. Run generate-articles.js first.');
+    process.exit(1);
+  }
+
+  const articles = JSON.parse(fs.readFileSync(ARTICLES_JSON, 'utf-8'));
+  console.log(`Found ${articles.length} articles`);
+
+  // Generate RSS feed
+  const rss = generateRssFeed(articles);
+  fs.writeFileSync(RSS_OUTPUT, rss);
+  console.log(`✓ Generated ${RSS_OUTPUT}`);
+
+  // Generate Atom feed
+  const atom = generateAtomFeed(articles);
+  fs.writeFileSync(ATOM_OUTPUT, atom);
+  console.log(`✓ Generated ${ATOM_OUTPUT}`);
+
+  console.log('\nDone! 🎉');
+}
+
+main();


### PR DESCRIPTION
# 概要

ブログ記事の静的ページ生成機能とRSS/Atomフィード生成機能を実装しました。

## 変更内容

### ブログ記事静的ページ生成
- `marked` と `highlight.js` 依存関係追加
- `scripts/generate-articles.js` を拡張して16記事の静的HTMLページを生成
- Markdownファイルから記事メタデータとコンテンツを抽出
- シンタックスハイライト付きでHTML変換
- sitemap.xmlに記事URLを自動追加

### RSS/Atomフィード生成
- `scripts/generate-feed.js` を新規作成
  - RSS 2.0とAtom 1.0の両フォーマットを生成
  - 記事タイトル（絵文字付き）、URL、公開日、カテゴリ、トピックタグを含む
  - 最大20記事まで対応
- `/feed.xml` (RSS 2.0) と `/atom.xml` (Atom 1.0) を生成
- `blog/index.html` にRSS autodiscoveryリンク追加
- UIにRSSアイコン追加（Zennバッジの横に配置）

## 関連情報

- Resolves #38 (sitemap.xml 自動生成 + 記事URL/lastmod 追加（＋RSS）)
- 16件のブログ記事が静的ページとして公開可能に
- RSSフィードによりブログのフォローが可能に

🤖 Generated with [Claude Code](https://claude.com/claude-code)