### PR TITLE
feat: 構造化データ拡充（BlogPosting/CollectionPage/BreadcrumbList）

### DIFF
--- a/articles/01a6f8c9376ff1.md
+++ b/articles/01a6f8c9376ff1.md
@@ -10,6 +10,7 @@ topics:
   - "suscriber"
 published: true
 published_at: "2024-04-05 12:07"
+updated_at: "2024-04-05 12:07"
 ---
 
 ## LaravelのSubscriber　is 何

--- a/articles/0b4b923b3c1edc.md
+++ b/articles/0b4b923b3c1edc.md
@@ -8,6 +8,7 @@ topics:
   - "pest"
 published: true
 published_at: "2023-03-27 20:03"
+updated_at: "2023-03-27 20:03"
 ---
 
 # 背景

--- a/articles/2b6012f10b777d.md
+++ b/articles/2b6012f10b777d.md
@@ -10,6 +10,7 @@ topics:
   - "contextualbinding"
 published: true
 published_at: "2025-04-14 11:26"
+updated_at: "2025-04-14 11:26"
 publication_name: "studio"
 ---
 

--- a/articles/33b761aeb80772.md
+++ b/articles/33b761aeb80772.md
@@ -8,6 +8,7 @@ topics:
   - "favicon"
 published: true
 published_at: "2023-07-25 17:32"
+updated_at: "2023-07-25 17:32"
 ---
 
 # バージョン情報

--- a/articles/3828103014143e.md
+++ b/articles/3828103014143e.md
@@ -9,6 +9,7 @@ topics:
   - "channeltalk"
 published: true
 published_at: "2023-01-06 14:40"
+updated_at: "2023-01-06 14:40"
 ---
 
 ## 背景

--- a/articles/431afa748fbed1.md
+++ b/articles/431afa748fbed1.md
@@ -10,6 +10,7 @@ topics:
   - "serena"
 published: true
 published_at: "2025-07-31 11:13"
+updated_at: "2025-07-31 11:13"
 publication_name: "studio"
 ---
 

--- a/articles/46d7b3e367d930.md
+++ b/articles/46d7b3e367d930.md
@@ -8,6 +8,7 @@ topics:
   - "framermotion"
 published: true
 published_at: "2024-01-14 02:18"
+updated_at: "2024-01-14 02:18"
 ---
 
 ## バージョン

--- a/articles/8b5deda18d7967.md
+++ b/articles/8b5deda18d7967.md
@@ -7,6 +7,7 @@ topics:
   - "vimeo"
 published: true
 published_at: "2023-01-16 10:38"
+updated_at: "2023-01-16 10:38"
 ---
 
 ## 背景

--- a/articles/ad3ddb6ff13abe.md
+++ b/articles/ad3ddb6ff13abe.md
@@ -10,6 +10,7 @@ topics:
   - "pecl"
 published: true
 published_at: "2024-12-04 13:40"
+updated_at: "2024-12-04 13:40"
 publication_name: "studio"
 ---
 

--- a/articles/afc2c86306ca88.md
+++ b/articles/afc2c86306ca88.md
@@ -10,6 +10,7 @@ topics:
   - "sail"
 published: true
 published_at: "2023-01-17 18:03"
+updated_at: "2023-01-17 18:03"
 ---
 
 ## Laravel特化のDocker環境

--- a/articles/c438613853e766.md
+++ b/articles/c438613853e766.md
@@ -8,6 +8,7 @@ topics:
   - "iterm2"
 published: true
 published_at: "2025-08-12 09:47"
+updated_at: "2025-08-12 09:47"
 publication_name: "studio"
 ---
 

--- a/articles/ce0260ada646f4.md
+++ b/articles/ce0260ada646f4.md
@@ -10,6 +10,7 @@ topics:
   - "mysqldump"
 published: true
 published_at: "2025-02-03 14:13"
+updated_at: "2025-02-03 14:13"
 publication_name: "studio"
 ---
 

--- a/articles/d261ae9bcb4d6b.md
+++ b/articles/d261ae9bcb4d6b.md
@@ -10,6 +10,7 @@ topics:
   - "sendgridnodejs"
 published: true
 published_at: "2023-07-31 23:55"
+updated_at: "2023-07-31 23:55"
 ---
 
 # 早速ですが、問題です。

--- a/articles/da5be52d57e9a1.md
+++ b/articles/da5be52d57e9a1.md
@@ -10,6 +10,7 @@ topics:
   - "worldwideweb"
 published: true
 published_at: "2025-12-10 13:20"
+updated_at: "2025-12-10 13:20"
 publication_name: "studio"
 ---
 

--- a/articles/e78c7f39dab62f.md
+++ b/articles/e78c7f39dab62f.md
@@ -10,6 +10,7 @@ topics:
   - "pino"
 published: true
 published_at: "2023-08-18 15:52"
+updated_at: "2023-08-18 15:52"
 ---
 
 # 何がしたかったのか

--- a/articles/f3948e577a3b65.md
+++ b/articles/f3948e577a3b65.md
@@ -9,6 +9,7 @@ topics:
   - "419"
 published: true
 published_at: "2024-04-22 20:49"
+updated_at: "2024-04-22 20:49"
 ---
 
 ## 419エラー

--- a/blog/01a6f8c9376ff1/index.html
+++ b/blog/01a6f8c9376ff1/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/01a6f8c9376ff1/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/01a6f8c9376ff1/#article",
+  "headline": "[Laravel Subscriber] 関数名を文字列で定義するの怖くない？",
+  "description": "[Laravel Subscriber] 関数名を文字列で定義するの怖くない？ - Tech article by wadakatu",
+  "datePublished": "2024-04-05T12:07:00",
+  "dateModified": "2024-04-05T12:07:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/01a6f8c9376ff1/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/01a6f8c9376ff1/"
+  },
+  "inLanguage": "ja",
+  "keywords": "laravel, php, phpunit, mockery, suscriber",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "[Laravel Subscriber] 関数名を文字列で定義するの怖くない？"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/0b4b923b3c1edc/index.html
+++ b/blog/0b4b923b3c1edc/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/0b4b923b3c1edc/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/0b4b923b3c1edc/#article",
+  "headline": "Laravel & Inertiaのテストでresource/js以外をテスト対象にする方法",
+  "description": "Laravel & Inertiaのテストでresource/js以外をテスト対象にする方法 - Tech article by wadakatu",
+  "datePublished": "2023-03-27T20:03:00",
+  "dateModified": "2023-03-27T20:03:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/0b4b923b3c1edc/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/0b4b923b3c1edc/"
+  },
+  "inLanguage": "ja",
+  "keywords": "laravel, inertia, pest",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Laravel & Inertiaのテストでresource/js以外をテスト対象にする方法"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/2b6012f10b777d/index.html
+++ b/blog/2b6012f10b777d/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/2b6012f10b777d/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/2b6012f10b777d/#article",
+  "headline": "Contextual Bindingの仕様変更について（Lumen v10 -> v11）",
+  "description": "Contextual Bindingの仕様変更について（Lumen v10 -> v11） - Tech article by wadakatu",
+  "datePublished": "2025-04-14T11:26:00",
+  "dateModified": "2025-04-14T11:26:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/2b6012f10b777d/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/2b6012f10b777d/"
+  },
+  "inLanguage": "ja",
+  "keywords": "laravel, php, lumen, servicecontainer, contextualbinding",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Contextual Bindingの仕様変更について（Lumen v10 -> v11）"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/33b761aeb80772/index.html
+++ b/blog/33b761aeb80772/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/33b761aeb80772/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/33b761aeb80772/#article",
+  "headline": "【Next.js v13】 Metadata APIを使ってFaviconを設定",
+  "description": "【Next.js v13】 Metadata APIを使ってFaviconを設定 - Tech article by wadakatu",
+  "datePublished": "2023-07-25T17:32:00",
+  "dateModified": "2023-07-25T17:32:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/33b761aeb80772/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/33b761aeb80772/"
+  },
+  "inLanguage": "ja",
+  "keywords": "javascript, nextjs, favicon",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "【Next.js v13】 Metadata APIを使ってFaviconを設定"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/3828103014143e/index.html
+++ b/blog/3828103014143e/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/3828103014143e/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/3828103014143e/#article",
+  "headline": "【Inertia.js】[object Object] could not be cloned.の対処法",
+  "description": "【Inertia.js】[object Object] could not be cloned.の対処法 - Tech article by wadakatu",
+  "datePublished": "2023-01-06T14:40:00",
+  "dateModified": "2023-01-06T14:40:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/3828103014143e/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/3828103014143e/"
+  },
+  "inLanguage": "ja",
+  "keywords": "javascript, laravel, inertia, channeltalk",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "【Inertia.js】[object Object] could not be cloned.の対処法"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/431afa748fbed1/index.html
+++ b/blog/431afa748fbed1/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/431afa748fbed1/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/431afa748fbed1/#article",
+  "headline": "🚀 Claude Code × Serena MCP：もうバージョンダウンしなくても良いのか...?",
+  "description": "🚀 Claude Code × Serena MCP：もうバージョンダウンしなくても良いのか...? - Tech article by wadakatu",
+  "datePublished": "2025-07-31T11:13:00",
+  "dateModified": "2025-07-31T11:13:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/431afa748fbed1/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/431afa748fbed1/"
+  },
+  "inLanguage": "ja",
+  "keywords": "ai, mcp, claude, vibecoding, serena",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "🚀 Claude Code × Serena MCP：もうバージョンダウンしなくても良いのか...?"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/46d7b3e367d930/index.html
+++ b/blog/46d7b3e367d930/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/46d7b3e367d930/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/46d7b3e367d930/#article",
+  "headline": "[Framer motion] アニメーション動作後にposition: fixedが効かない時の対処法",
+  "description": "[Framer motion] アニメーション動作後にposition: fixedが効かない時の対処法 - Tech article by wadakatu",
+  "datePublished": "2024-01-14T02:18:00",
+  "dateModified": "2024-01-14T02:18:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/46d7b3e367d930/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/46d7b3e367d930/"
+  },
+  "inLanguage": "ja",
+  "keywords": "framer, react, framermotion",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "[Framer motion] アニメーション動作後にposition: fixedが効かない時の対処法"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/8b5deda18d7967/index.html
+++ b/blog/8b5deda18d7967/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/8b5deda18d7967/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/8b5deda18d7967/#article",
+  "headline": "【vimeo.js】doNotTrack is not defined.",
+  "description": "【vimeo.js】doNotTrack is not defined. - Tech article by wadakatu",
+  "datePublished": "2023-01-16T10:38:00",
+  "dateModified": "2023-01-16T10:38:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/8b5deda18d7967/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/8b5deda18d7967/"
+  },
+  "inLanguage": "ja",
+  "keywords": "javascript, vimeo",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "【vimeo.js】doNotTrack is not defined."
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/ad3ddb6ff13abe/index.html
+++ b/blog/ad3ddb6ff13abe/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/ad3ddb6ff13abe/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/ad3ddb6ff13abe/#article",
+  "headline": "pecl install grpcで大量のwarningメッセージ出た時の対処法",
+  "description": "pecl install grpcで大量のwarningメッセージ出た時の対処法 - Tech article by wadakatu",
+  "datePublished": "2024-12-04T13:40:00",
+  "dateModified": "2024-12-04T13:40:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/ad3ddb6ff13abe/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/ad3ddb6ff13abe/"
+  },
+  "inLanguage": "ja",
+  "keywords": "php, grpc, dockerfile, gnu, pecl",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "pecl install grpcで大量のwarningメッセージ出た時の対処法"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/afc2c86306ca88/index.html
+++ b/blog/afc2c86306ca88/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/afc2c86306ca88/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/afc2c86306ca88/#article",
+  "headline": "PHP/Composerなしで始めるLaravel/Sail入門",
+  "description": "PHP/Composerなしで始めるLaravel/Sail入門 - Tech article by wadakatu",
+  "datePublished": "2023-01-17T18:03:00",
+  "dateModified": "2023-01-17T18:03:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/afc2c86306ca88/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/afc2c86306ca88/"
+  },
+  "inLanguage": "ja",
+  "keywords": "docker, laravel, php, composer, sail",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "PHP/Composerなしで始めるLaravel/Sail入門"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/c438613853e766/index.html
+++ b/blog/c438613853e766/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/c438613853e766/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/c438613853e766/#article",
+  "headline": "\\5を追加したら動いた！iTerm2でPhpStormを起動する設定方法",
+  "description": "\\5を追加したら動いた！iTerm2でPhpStormを起動する設定方法 - Tech article by wadakatu",
+  "datePublished": "2025-08-12T09:47:00",
+  "dateModified": "2025-08-12T09:47:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/c438613853e766/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/c438613853e766/"
+  },
+  "inLanguage": "ja",
+  "keywords": "terminal, phpstorm, iterm2",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "\\5を追加したら動いた！iTerm2でPhpStormを起動する設定方法"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/ce0260ada646f4/index.html
+++ b/blog/ce0260ada646f4/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/ce0260ada646f4/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/ce0260ada646f4/#article",
+  "headline": "`php artisan schema:dump`で `TLS/SSL`に関するエラーが出た時の対処法",
+  "description": "`php artisan schema:dump`で `TLS/SSL`に関するエラーが出た時の対処法 - Tech article by wadakatu",
+  "datePublished": "2025-02-03T14:13:00",
+  "dateModified": "2025-02-03T14:13:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/ce0260ada646f4/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/ce0260ada646f4/"
+  },
+  "inLanguage": "ja",
+  "keywords": "laravel, mysql, php, mariadb, mysqldump",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "`php artisan schema:dump`で `TLS/SSL`に関するエラーが出た時の対処法"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/d261ae9bcb4d6b/index.html
+++ b/blog/d261ae9bcb4d6b/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/d261ae9bcb4d6b/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/d261ae9bcb4d6b/#article",
+  "headline": "sendgrid-nodejsでbaseUrlを変更するときに注意すること",
+  "description": "sendgrid-nodejsでbaseUrlを変更するときに注意すること - Tech article by wadakatu",
+  "datePublished": "2023-07-31T23:55:00",
+  "dateModified": "2023-07-31T23:55:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/d261ae9bcb4d6b/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/d261ae9bcb4d6b/"
+  },
+  "inLanguage": "ja",
+  "keywords": "javascript, typescript, node, sendgrid, sendgridnodejs",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "sendgrid-nodejsでbaseUrlを変更するときに注意すること"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/da5be52d57e9a1/index.html
+++ b/blog/da5be52d57e9a1/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/da5be52d57e9a1/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/da5be52d57e9a1/#article",
+  "headline": "W3C TPAC 2025参加レポ （Web標準ってどうやってできてるの？）",
+  "description": "W3C TPAC 2025参加レポ （Web標準ってどうやってできてるの？） - Tech article by wadakatu",
+  "datePublished": "2025-12-10T13:20:00",
+  "dateModified": "2025-12-10T13:20:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/da5be52d57e9a1/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/da5be52d57e9a1/"
+  },
+  "inLanguage": "ja",
+  "keywords": "w3c, report, tpac, kobe, worldwideweb",
+  "articleSection": "Life"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "W3C TPAC 2025参加レポ （Web標準ってどうやってできてるの？）"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/e78c7f39dab62f/index.html
+++ b/blog/e78c7f39dab62f/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/e78c7f39dab62f/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/e78c7f39dab62f/#article",
+  "headline": "Next.js初心者がLogを出すまでに苦労した話",
+  "description": "Next.js初心者がLogを出すまでに苦労した話 - Tech article by wadakatu",
+  "datePublished": "2023-08-18T15:52:00",
+  "dateModified": "2023-08-18T15:52:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/e78c7f39dab62f/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/e78c7f39dab62f/"
+  },
+  "inLanguage": "ja",
+  "keywords": "next, typescript, ecs, logger, pino",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Next.js初心者がLogを出すまでに苦労した話"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/f3948e577a3b65/index.html
+++ b/blog/f3948e577a3b65/index.html
@@ -28,6 +28,58 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog/f3948e577a3b65/">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "@id": "https://www.wadakatu.dev/blog/f3948e577a3b65/#article",
+  "headline": "[Laravel] 最も簡単で最も難しい419エラーの解決策",
+  "description": "[Laravel] 最も簡単で最も難しい419エラーの解決策 - Tech article by wadakatu",
+  "datePublished": "2024-04-22T20:49:00",
+  "dateModified": "2024-04-22T20:49:00",
+  "author": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "publisher": {
+    "@id": "https://www.wadakatu.dev/#person"
+  },
+  "image": "https://www.wadakatu.dev/ogp.webp",
+  "url": "https://www.wadakatu.dev/blog/f3948e577a3b65/",
+  "mainEntityOfPage": {
+    "@id": "https://www.wadakatu.dev/blog/f3948e577a3b65/"
+  },
+  "inLanguage": "ja",
+  "keywords": "laravel, php, csrf, 419",
+  "articleSection": "Tech"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.wadakatu.dev/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.wadakatu.dev/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "[Laravel] 最も簡単で最も難しい419エラーの解決策"
+    }
+  ]
+}
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="/ogp.webp">
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -29,6 +29,40 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.wadakatu.dev/blog">
 
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": "https://www.wadakatu.dev/blog/#page",
+    "name": "Blog | wadakatu",
+    "description": "Tech articles and learnings by wadakatu - Laravel, TypeScript, and web development.",
+    "url": "https://www.wadakatu.dev/blog/",
+    "author": {
+      "@id": "https://www.wadakatu.dev/#person"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://www.wadakatu.dev/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Blog"
+      }
+    ]
+  }
+  </script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">
 

--- a/data/articles.json
+++ b/data/articles.json
@@ -12,6 +12,7 @@
       "worldwideweb"
     ],
     "published_at": "2025-12-10T13:20:00",
+    "updated_at": "2025-12-10T13:20:00",
     "reading_time": 8
   },
   {
@@ -25,6 +26,7 @@
       "iterm2"
     ],
     "published_at": "2025-08-12T09:47:00",
+    "updated_at": "2025-08-12T09:47:00",
     "reading_time": 3
   },
   {
@@ -40,6 +42,7 @@
       "serena"
     ],
     "published_at": "2025-07-31T11:13:00",
+    "updated_at": "2025-07-31T11:13:00",
     "reading_time": 5
   },
   {
@@ -55,6 +58,7 @@
       "contextualbinding"
     ],
     "published_at": "2025-04-14T11:26:00",
+    "updated_at": "2025-04-14T11:26:00",
     "reading_time": 5
   },
   {
@@ -70,6 +74,7 @@
       "mysqldump"
     ],
     "published_at": "2025-02-03T14:13:00",
+    "updated_at": "2025-02-03T14:13:00",
     "reading_time": 3
   },
   {
@@ -85,6 +90,7 @@
       "pecl"
     ],
     "published_at": "2024-12-04T13:40:00",
+    "updated_at": "2024-12-04T13:40:00",
     "reading_time": 3
   },
   {
@@ -99,6 +105,7 @@
       "419"
     ],
     "published_at": "2024-04-22T20:49:00",
+    "updated_at": "2024-04-22T20:49:00",
     "reading_time": 2
   },
   {
@@ -114,6 +121,7 @@
       "suscriber"
     ],
     "published_at": "2024-04-05T12:07:00",
+    "updated_at": "2024-04-05T12:07:00",
     "reading_time": 3
   },
   {
@@ -127,6 +135,7 @@
       "framermotion"
     ],
     "published_at": "2024-01-14T02:18:00",
+    "updated_at": "2024-01-14T02:18:00",
     "reading_time": 2
   },
   {
@@ -142,6 +151,7 @@
       "pino"
     ],
     "published_at": "2023-08-18T15:52:00",
+    "updated_at": "2023-08-18T15:52:00",
     "reading_time": 3
   },
   {
@@ -157,6 +167,7 @@
       "sendgridnodejs"
     ],
     "published_at": "2023-07-31T23:55:00",
+    "updated_at": "2023-07-31T23:55:00",
     "reading_time": 1
   },
   {
@@ -170,6 +181,7 @@
       "favicon"
     ],
     "published_at": "2023-07-25T17:32:00",
+    "updated_at": "2023-07-25T17:32:00",
     "reading_time": 1
   },
   {
@@ -183,6 +195,7 @@
       "pest"
     ],
     "published_at": "2023-03-27T20:03:00",
+    "updated_at": "2023-03-27T20:03:00",
     "reading_time": 2
   },
   {
@@ -198,6 +211,7 @@
       "sail"
     ],
     "published_at": "2023-01-17T18:03:00",
+    "updated_at": "2023-01-17T18:03:00",
     "reading_time": 3
   },
   {
@@ -210,6 +224,7 @@
       "vimeo"
     ],
     "published_at": "2023-01-16T10:38:00",
+    "updated_at": "2023-01-16T10:38:00",
     "reading_time": 1
   },
   {
@@ -224,6 +239,7 @@
       "channeltalk"
     ],
     "published_at": "2023-01-06T14:40:00",
+    "updated_at": "2023-01-06T14:40:00",
     "reading_time": 1
   }
 ]


### PR DESCRIPTION
# 概要

ホームページ以外のページにJSON-LD構造化データを追加し、SEO/検索エンジンの理解を向上させる対応です。

## 変更内容

### 1. 記事ページの構造化データ追加
- **BlogPosting**: 記事のメタデータ（headline, datePublished, dateModified, author, publisher, keywords, articleSection）を追加
- **BreadcrumbList**: パンくずリスト（ホーム → ブログ → 記事タイトル）を追加

### 2. ブログ一覧ページの構造化データ追加
- **CollectionPage**: ブログ一覧ページの情報を追加
- **BreadcrumbList**: パンくずリスト（ホーム → ブログ）を追加

### 3. データ管理の改善
- 全記事のMarkdownに`updated_at`フィールドを追加（初期値は`published_at`と同じ）
- `generate-articles.js`にJSON-LD生成ロジックを追加
- `data/articles.json`に`updated_at`を出力

### 4. Person @idの共通化
- 既存の`https://www.wadakatu.dev/#person`を全記事のauthorとして参照

## 技術詳細

### 追加されたスキーマ
- **BlogPosting**: 各記事に対して構造化された記事情報
- **CollectionPage**: ブログ一覧ページの情報
- **BreadcrumbList**: サイト内のナビゲーション構造

### 変更ファイル（35ファイル）
- `articles/*.md`: 16ファイル（updated_at追加）
- `scripts/generate-articles.js`: JSON-LD生成機能を追加
- `blog/index.html`: CollectionPage/BreadcrumbListを追加
- `blog/*/index.html`: 16ファイル（自動生成、JSON-LD埋め込み済み）
- `data/articles.json`: updated_atフィールドを追加（自動生成）

## 期待される効果

- 検索エンジンによる記事内容の理解向上
- リッチリザルトでの表示可能性向上
- パンくずリストの検索結果表示
- 記事の公開日・更新日の明示化

## 関連情報

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>