### PR TITLE
feat: Complete JSON-LD structured data implementation (Issue #16)

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -31,6 +31,37 @@
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">
 
+  <!-- Structured Data (JSON-LD) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "@id": "https://www.wadakatu.dev/about/#page",
+    "name": "About | wadakatu",
+    "description": "Career and skills of wadakatu - Backend Developer @ Studio Inc. Active OSS contributor to Laravel ecosystem.",
+    "url": "https://www.wadakatu.dev/about/",
+    "mainEntity": {
+      "@id": "https://www.wadakatu.dev/#person"
+    },
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.wadakatu.dev/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "About"
+        }
+      ]
+    }
+  }
+  </script>
+
   <!-- PWA Manifest -->
   <link rel="manifest" href="/manifest.json">
 

--- a/index.html
+++ b/index.html
@@ -110,6 +110,21 @@
     ]
   }
   </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": "https://www.wadakatu.dev/#website",
+    "name": "wadakatu",
+    "alternateName": "wadakatu.dev",
+    "url": "https://www.wadakatu.dev/",
+    "description": "Backend Developer @ Studio Inc. Building no-code website builders. Active OSS contributor to Laravel ecosystem.",
+    "publisher": {
+      "@id": "https://www.wadakatu.dev/#person"
+    },
+    "inLanguage": ["en", "ja"]
+  }
+  </script>
 
   <!-- PWA Manifest -->
   <link rel="manifest" href="/manifest.json">

--- a/projects/index.html
+++ b/projects/index.html
@@ -31,6 +31,37 @@
   <!-- Favicon -->
   <link rel="icon" type="image/webp" href="../ogp.webp">
 
+  <!-- Structured Data (JSON-LD) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": "https://www.wadakatu.dev/projects/#page",
+    "name": "Projects | wadakatu",
+    "description": "OSS contributions and personal projects by wadakatu - Laravel, TypeScript, and frontend experiments.",
+    "url": "https://www.wadakatu.dev/projects/",
+    "author": {
+      "@id": "https://www.wadakatu.dev/#person"
+    },
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.wadakatu.dev/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Projects"
+        }
+      ]
+    }
+  }
+  </script>
+
   <!-- PWA Manifest -->
   <link rel="manifest" href="/manifest.json">
 


### PR DESCRIPTION
# 概要

Issue #16のJSON-LD構造化データ実装を完了しました。WebSite schema、AboutPage + BreadcrumbList、CollectionPage + BreadcrumbListを追加し、全ページで構造化データが整備されました。

## 変更内容

**追加したJSON-LDスキーマ:**

1. **index.html**
   - WebSite schema を追加
   - `@id: https://www.wadakatu.dev/#website` で識別可能
   - 既存のPerson entityを `publisher` として参照

2. **about/index.html**  
   - AboutPage schema を追加
   - BreadcrumbList を `breadcrumb` プロパティとして埋め込み
   - `mainEntity` で既存のPerson entityを参照

3. **projects/index.html**
   - CollectionPage schema を追加  
   - BreadcrumbList を `breadcrumb` プロパティとして埋め込み
   - `author` で既存のPerson entityを参照

**実装パターン:**
- 全て既存の `@id: https://www.wadakatu.dev/#person` を活用
- BreadcrumbListは親スキーマ内に埋め込み形式で実装
- SearchActionは現時点で含めない（サイト内検索機能がないため）

**SEO効果:**
- Google検索結果でのリッチスニペット表示に対応
- パンくずリストの表示対応
- サイト全体の構造をSearch Engineに明示

## 関連情報

- Closes #16
- 実装計画: `/Users/wadakatu/.claude/plans/whimsical-wondering-bengio.md`