### PR TITLE
Bugfix: Zenn固有の画像サイズ構文をimgタグに変換

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,7 @@
     "": {
       "name": "wadakatu.github.io",
       "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "highlight.js": "^11.11.1",
-        "marked": "^17.0.1"
-      },
+      "license": "MIT",
       "devDependencies": {
         "@astrojs/sitemap": "^3.6.1",
         "astro": "^5.16.7"
@@ -2843,15 +2839,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -3044,18 +3031,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/marked": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
-      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "type": "git",
     "url": "git+https://github.com/wadakatu/wadakatu.github.io.git"
   },
-  "keywords": ["portfolio", "blog", "astro"],
+  "keywords": [
+    "portfolio",
+    "blog",
+    "astro"
+  ],
   "author": "wadakatu",
   "license": "MIT",
   "bugs": {

--- a/src/content/blog/46d7b3e367d930.md
+++ b/src/content/blog/46d7b3e367d930.md
@@ -79,7 +79,7 @@ export default funciton Header(){
 ページに遷移して、何もスクロールしないでハンバーガーメニューをクリックすると綺麗にナビゲーションメニューが画面いっぱいに表示されます。
 いい感じです。
 
-![](https://storage.googleapis.com/zenn-user-upload/e9ce54dfc097-20240114.png =200x)
+<img src="https://storage.googleapis.com/zenn-user-upload/e9ce54dfc097-20240114.png" width="200" alt="" />
 
 ---
 
@@ -87,7 +87,7 @@ export default funciton Header(){
 アニメーション起動後に、ハンバーガーメニューをクリックすると何故か画面全体にナビゲーションメニューが表示されません。
 その親要素であるヘッダーの要素全体に対して、`position:fixed`が効いてしまうようになりました。
 
-![](https://storage.googleapis.com/zenn-user-upload/35f7addc659a-20240114.png =200x)
+<img src="https://storage.googleapis.com/zenn-user-upload/35f7addc659a-20240114.png" width="200" alt="" />
 
 
 ## 原因

--- a/src/content/blog/da5be52d57e9a1.md
+++ b/src/content/blog/da5be52d57e9a1.md
@@ -40,7 +40,7 @@ https://www.w3.org/2025/11/TPAC/schedule.html
 
 参考までに、11/10（月）の1日だけで、膨大な会議があります。
 
-![](https://storage.googleapis.com/zenn-user-upload/e2a99182db0d-20251127.png =750x)
+<img src="https://storage.googleapis.com/zenn-user-upload/e2a99182db0d-20251127.png" width="750" alt="" />
 
 ## 参加した感想
 
@@ -53,7 +53,7 @@ https://www.w3.org/2025/11/TPAC/schedule.html
 （すごい所に来てしまった...という感じでした）
 
 名札はこんな感じです。
-![](https://storage.googleapis.com/zenn-user-upload/f1ad4fffef76-20251128.jpg =250x)
+<img src="https://storage.googleapis.com/zenn-user-upload/f1ad4fffef76-20251128.jpg" width="250" alt="" />
 
 ---
 
@@ -72,7 +72,7 @@ https://www.w3.org/2025/11/TPAC/schedule.html
 午前8時から始まる受付に間に合うように大阪を朝6時ごろに出発しました。
 場所は、神戸国際会議場でした。
 
-![](https://storage.googleapis.com/zenn-user-upload/b5aee7f18cbb-20251203.jpeg =250x)
+<img src="https://storage.googleapis.com/zenn-user-upload/b5aee7f18cbb-20251203.jpeg" width="250" alt="" />
 
 外観は古めかしい感じでしたが、中は綺麗で非常に居心地が良かったです。
 
@@ -115,7 +115,7 @@ Web Fonts WGの会議に参加している人数はかなり小規模でした�
 一通り予定されていたアジェンダをこなした後は、Google Fontsの人に用意してきたIFTのデモを見せたり、雑談をすることができました。
 デモはsuzukiさんが用意してくださったのですが、IFTを使ったデモはまだこの世に数が少ないので非常に興味を持っていただけたようでした。別の会議に参加していたエンジニアの方も乱入してみんなでデモを触りながら、IFTが今後こういう機能を用意してくれると嬉しいなどの話ができました。
 
-![](https://storage.googleapis.com/zenn-user-upload/62a331668f2e-20251209.png =350x)
+<img src="https://storage.googleapis.com/zenn-user-upload/62a331668f2e-20251209.png" width="350" alt="" />
 
 この会議を通して私の心に残っていることは、議論のレベルの高さはもちろんですが、一番は「みんな自分と同じように悩むことあるんだな」ということです。
 IFTテストケースの話じゃないんかい！と思われるかもしれませんが、自分にとってはこれを知れたのはかなり大きな収穫だと感じています。


### PR DESCRIPTION
# 概要

Zenn固有のMarkdown画像サイズ構文 (`=750x`) がそのまま表示される問題を修正。

## 変更内容

Zennの独自Markdown構文 `![](url =WIDTHx)` はAstroの標準Markdownパーサーでは解析できないため、標準的なHTMLのimgタグに変換しました。

- `da5be52d57e9a1.md`: 4箇所の構文を変換 (width: 750, 250, 250, 350)
- `46d7b3e367d930.md`: 2箇所の構文を変換 (width: 200, 200)

**変換例:**
```markdown
# Before (Zenn構文)
![](https://storage.googleapis.com/.../image.png =750x)

# After (標準HTML)
<img src="https://storage.googleapis.com/.../image.png" width="750" alt="" />
```

## 関連情報

- Closes #73