### PR TITLE
feat: add TOC (Table of Contents) generation for blog articles

### DIFF
--- a/public/scripts/toc.js
+++ b/public/scripts/toc.js
@@ -24,6 +24,7 @@
   let mobileBackdrop = null;
   let mobileTrigger = null;
   let isInitialized = false;
+  let prefersReducedMotion = false;
 
   /**
    * Initialize TOC
@@ -33,6 +34,9 @@
 
     const content = document.querySelector(CONFIG.contentSelector);
     if (!content) return;
+
+    // Check for reduced motion preference
+    prefersReducedMotion = checkReducedMotion();
 
     headings = Array.from(document.querySelectorAll(CONFIG.headingSelectors));
 
@@ -242,13 +246,39 @@
   }
 
   /**
+   * Check if user prefers reduced motion
+   * Uses both CSS media query and JavaScript check for comprehensive coverage
+   */
+  function checkReducedMotion() {
+    // Check via matchMedia (handles both CSS preference and JS-triggered check)
+    if (window.matchMedia) {
+      const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+      // Listen for changes to the preference
+      mediaQuery.addEventListener('change', (e) => {
+        prefersReducedMotion = e.matches;
+      });
+
+      return mediaQuery.matches;
+    }
+    return false;
+  }
+
+  /**
+   * Get scroll behavior based on user preference
+   */
+  function getScrollBehavior() {
+    return prefersReducedMotion ? 'auto' : 'smooth';
+  }
+
+  /**
    * Scroll to heading with offset
    */
   function scrollToHeading(heading) {
     const top = heading.getBoundingClientRect().top + window.pageYOffset - CONFIG.scrollOffset;
     window.scrollTo({
       top: top,
-      behavior: 'smooth'
+      behavior: getScrollBehavior()
     });
   }
 
@@ -284,7 +314,7 @@
       const listRect = tocList.getBoundingClientRect();
 
       if (itemRect.top < listRect.top || itemRect.bottom > listRect.bottom) {
-        activeItem.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        activeItem.scrollIntoView({ block: 'nearest', behavior: getScrollBehavior() });
       }
     }
   }

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -174,6 +174,7 @@ const jsonLd = [
 
   <Fragment slot="scripts">
     <script is:inline src="/scripts/code-copy.js"></script>
+    <script is:inline src="/scripts/toc.js"></script>
     <script is:inline>
       // JST Clock
       function updateJSTTime() {


### PR DESCRIPTION
## Summary
- ブログ記事にTOC（目次）を自動生成するスクリプトを有効化
- スムーススクロールにreduced motion対応を追加
- スクロールに応じた現在位置ハイライト機能

## 機能
- h2, h3, h4見出しから目次を動的に生成
- サイドバー固定表示（デスクトップ）
- モバイルではモーダル表示
- 読了プログレスバー
- reduced motion設定を尊重したスムーススクロール

## Test plan
- [ ] デスクトップでTOCがサイドバーに表示されること
- [ ] スクロールに応じてアクティブアイテムが切り替わること
- [ ] TOCリンクをクリックして該当セクションにスクロールすること
- [ ] モバイルでTOCボタンが表示され、モーダルが開くこと
- [ ] reduced motion設定時にスムーススクロールが無効化されること

Closes #93

🤖 Generated with [Claude Code](https://claude.ai/code)